### PR TITLE
Replace host header with x-forwarded-host

### DIFF
--- a/packages/node-bridge/src/bridge.ts
+++ b/packages/node-bridge/src/bridge.ts
@@ -12,6 +12,11 @@ import {
   request,
 } from 'http';
 
+// Remember that all header names are lower-cased in API Gateway context
+const HEADER_KEY_X_FORWARDED_HOST = 'x-forwarded-host';
+const HEADER_KEY_COOKIE = 'cookie';
+const HEADER_KEY_HOST = 'host';
+
 export interface NowProxyRequest {
   method: string;
   path: string;
@@ -79,7 +84,13 @@ function normalizeAPIGatewayProxyEvent(
   // API Gateway 2.0 payload splits cookie header from the rest,
   // so we need to readd them
   if (cookies) {
-    headers['cookie'] = cookies.join('; ');
+    headers[HEADER_KEY_COOKIE] = cookies.join('; ');
+  }
+
+  // Replace the `host` header with the value of `X-Forwarded-Host` if available
+  if (HEADER_KEY_X_FORWARDED_HOST in headers) {
+    headers[HEADER_KEY_HOST] = headers[HEADER_KEY_X_FORWARDED_HOST];
+    delete headers[HEADER_KEY_X_FORWARDED_HOST];
   }
 
   if (body) {

--- a/packages/node-bridge/test/bridge.test.js
+++ b/packages/node-bridge/test/bridge.test.js
@@ -297,8 +297,7 @@ test('[APIGatewayProxyEvent] Replace Host header with X-Forwarded-Host', async (
       host: 'example.com',
     })
   );
-  expect(body.headers['x-forwarded-host']).toBeUndefined()
-
+  expect(body.headers['x-forwarded-host']).toBeUndefined();
 
   server.close();
 });

--- a/packages/proxy/src/handler.ts
+++ b/packages/proxy/src/handler.ts
@@ -128,6 +128,11 @@ export async function handler(event: CloudFrontRequestEvent) {
         custom: customOrigin,
       };
 
+      // Add X-Forwarded-Host header which contains the original header
+      if (request.headers['host']) {
+        headers['X-Forwarded-Host'] = request.headers['host'][0].value;
+      }
+
       // Modify `Host` header to match the external host
       headers.host = apiEndpoint;
 
@@ -143,6 +148,11 @@ export async function handler(event: CloudFrontRequestEvent) {
       request.origin = {
         custom: customOrigin,
       };
+
+      // Add X-Forwarded-Host header which contains the original header
+      if (request.headers['host']) {
+        headers['X-Forwarded-Host'] = request.headers['host'][0].value;
+      }
 
       // Modify `Host` header to match the external host
       headers.host = customOrigin.domainName;

--- a/packages/proxy/src/handler.ts
+++ b/packages/proxy/src/handler.ts
@@ -3,31 +3,22 @@ import {
   CloudFrontHeaders,
   CloudFrontResultResponse,
   CloudFrontRequestEvent,
+  CloudFrontRequest,
 } from 'aws-lambda';
 
-import { ProxyConfig, HTTPHeaders, RouteResult } from './types';
-import { Proxy } from './proxy';
 import { fetchProxyConfig } from './util/fetch-proxy-config';
+import { generateCloudFrontHeaders } from './util/generate-cloudfront-headers';
+import { ProxyConfig, RouteResult } from './types';
+import { Proxy } from './proxy';
 import {
   createCustomOriginFromApiGateway,
   createCustomOriginFromUrl,
+  serveRequestFromCustomOrigin,
+  serveRequestFromS3Origin,
 } from './util/custom-origin';
 
 let proxyConfig: ProxyConfig;
 let proxy: Proxy;
-
-function convertToCloudFrontHeaders(
-  initialHeaders: CloudFrontHeaders,
-  headers: HTTPHeaders
-): CloudFrontHeaders {
-  const cloudFrontHeaders: CloudFrontHeaders = { ...initialHeaders };
-  for (const key in headers) {
-    const lowercaseKey = key.toLowerCase();
-    cloudFrontHeaders[lowercaseKey] = [{ key, value: headers[key] }];
-  }
-
-  return cloudFrontHeaders;
-}
 
 /**
  * Checks if a route result issued a redirect
@@ -43,7 +34,7 @@ function isRedirect(
     if ('Location' in routeResult.headers) {
       let headers: CloudFrontHeaders = {};
 
-      // If the redirect is permanent, add caching it
+      // If the redirect is permanent, cache the result
       if (routeResult.status === 301 || routeResult.status === 308) {
         headers['cache-control'] = [
           {
@@ -56,7 +47,7 @@ function isRedirect(
       return {
         status: routeResult.status.toString(),
         statusDescription: STATUS_CODES[routeResult.status],
-        headers: convertToCloudFrontHeaders(headers, routeResult.headers),
+        headers: generateCloudFrontHeaders(headers, routeResult.headers),
       };
     }
   }
@@ -64,7 +55,22 @@ function isRedirect(
   return false;
 }
 
-export async function handler(event: CloudFrontRequestEvent) {
+/**
+ * Internal handler that is called by the handler.
+ *
+ * @param event - Incoming event from CloudFront
+ *    @see {@link http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html}
+ * @returns CloudFront request or response modified by the proxy.
+ */
+async function main(
+  event: CloudFrontRequestEvent
+): Promise<CloudFrontRequest | CloudFrontResultResponse> {
+  /**
+   * ! Important !
+   * The `request` object should only be modified when the function returns.
+   * Changing properties inside of the function may cause unwanted side-effects
+   * that are difficult to track.
+   */
   const { request } = event.Records[0].cf;
   const configEndpoint = request.origin!.s3!.customHeaders[
     'x-env-config-endpoint'
@@ -84,113 +90,96 @@ export async function handler(event: CloudFrontRequestEvent) {
     }
   } catch (err) {
     console.error('Error while initialization:', err);
-    return request;
+    return serveRequestFromS3Origin(request);
   }
+
+  // Check if we have a prerender route
+  // Bypasses proxy
+  if (request.uri in proxyConfig.prerenders) {
+    const customOrigin = createCustomOriginFromApiGateway(
+      apiEndpoint,
+      `/${proxyConfig.prerenders[request.uri].lambda}`
+    );
+    return serveRequestFromCustomOrigin(request, customOrigin);
+  }
+
+  // Handle request by proxy
 
   // Append query string if we have one
   // @see: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html
   const requestPath = `${request.uri}${
     request.querystring !== '' ? `?${request.querystring}` : ''
   }`;
+  const proxyResult = proxy.route(requestPath);
 
-  // Check if we have a prerender route
-  // Bypasses proxy
-  if (request.uri in proxyConfig.prerenders) {
+  // Check for redirect
+  const redirect = isRedirect(proxyResult);
+  if (redirect) {
+    return redirect;
+  }
+
+  // Check if route is served by lambda
+  if (proxyResult.target === 'lambda') {
     // Modify request to be served from Api Gateway
     const customOrigin = createCustomOriginFromApiGateway(
       apiEndpoint,
-      `/${proxyConfig.prerenders[request.uri].lambda}`
+      proxyResult.dest
     );
-    request.origin = {
-      custom: customOrigin,
-    };
 
-    // Modify `Host` header to match the external host
-    headers.host = apiEndpoint;
-  } else {
-    // Handle by proxy
-    const proxyResult = proxy.route(requestPath);
+    // Append querystring if we have any
+    const querystring = proxyResult.uri_args
+      ? proxyResult.uri_args.toString()
+      : '';
 
-    // Check for redirect
-    const redirect = isRedirect(proxyResult);
-    if (redirect) {
-      return redirect;
-    }
-
-    // Check if route is served by lambda
-    if (proxyResult.target === 'lambda') {
-      // Modify request to be served from Api Gateway
-      const customOrigin = createCustomOriginFromApiGateway(
-        apiEndpoint,
-        proxyResult.dest
-      );
-      request.origin = {
-        custom: customOrigin,
-      };
-
-      // Add X-Forwarded-Host header which contains the original header
-      if (request.headers['host']) {
-        headers['X-Forwarded-Host'] = request.headers['host'][0].value;
-      }
-
-      // Modify `Host` header to match the external host
-      headers.host = apiEndpoint;
-
-      // Append querystring if we have any
-      request.querystring = proxyResult.uri_args
-        ? proxyResult.uri_args.toString()
-        : '';
-    } else if (proxyResult.target === 'url') {
-      // Modify request to be served from external host
-      const [customOrigin, destUrl] = createCustomOriginFromUrl(
-        proxyResult.dest
-      );
-      request.origin = {
-        custom: customOrigin,
-      };
-
-      // Add X-Forwarded-Host header which contains the original header
-      if (request.headers['host']) {
-        headers['X-Forwarded-Host'] = request.headers['host'][0].value;
-      }
-
-      // Modify `Host` header to match the external host
-      headers.host = customOrigin.domainName;
-
-      // Modify URI to match the path
-      request.uri = destUrl.pathname;
-
-      // Append querystring if we have any
-      request.querystring = proxyResult.uri_args
-        ? proxyResult.uri_args.toString()
-        : '';
-    } else {
-      // Route is served by S3 bucket
-      const notFound =
-        proxyResult.phase === 'error' && proxyResult.status === 404;
-
-      if (!notFound && proxyResult.found) {
-        request.uri = proxyResult.dest;
-      }
-
-      // Replace the last / with /index when requesting the resource from S3
-      request.uri = request.uri.replace(/\/$/, '/index');
-
-      // Send 404 directly to S3 bucket for handling without rewrite
-      if (notFound) {
-        return request;
-      }
-    }
-
-    headers = { ...proxyResult.headers, ...headers };
+    return serveRequestFromCustomOrigin(
+      request,
+      customOrigin,
+      proxyResult.headers,
+      querystring
+    );
   }
 
-  // Modify headers
-  request.headers = convertToCloudFrontHeaders(request.headers, headers);
+  if (proxyResult.target === 'url') {
+    // Modify request to be served from external host
+    const [customOrigin, destUrl] = createCustomOriginFromUrl(proxyResult.dest);
+    // Modify URI to match the path
+    const uri = destUrl.pathname;
 
-  if (!request.uri) {
-    request.uri = '/';
+    // Append querystring if we have any
+    const querystring = proxyResult.uri_args
+      ? proxyResult.uri_args.toString()
+      : '';
+
+    return serveRequestFromCustomOrigin(
+      request,
+      customOrigin,
+      proxyResult.headers,
+      querystring,
+      uri
+    );
   }
 
-  return request;
+  // Route is served by S3 bucket
+  const notFound = proxyResult.phase === 'error' && proxyResult.status === 404;
+  const uri = !notFound && proxyResult.found ? proxyResult.dest : undefined;
+  return serveRequestFromS3Origin(request, uri);
+}
+
+/**
+ * Handler that is called by Lambda@Edge.
+ *
+ * @param event - Incoming event from CloudFront
+ *    @see {@link http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html}
+ * @returns CloudFront request or response modified by the proxy.
+ */
+export async function handler(
+  event: CloudFrontRequestEvent
+): Promise<CloudFrontRequest | CloudFrontResultResponse> {
+  try {
+    return main(event);
+  } catch (error) {
+    // Something went terribly wrong - Should never be called!
+    console.error('Unexpected error occurred: ', error);
+    return event.Records[0].cf.request;
+  }
 }

--- a/packages/proxy/src/util/generate-cloudfront-headers.ts
+++ b/packages/proxy/src/util/generate-cloudfront-headers.ts
@@ -1,0 +1,29 @@
+import { CloudFrontHeaders } from 'aws-lambda';
+
+import { HTTPHeaders } from '../types';
+
+/**
+ * Converts a key value object of headers to the CloudFront format.
+ *
+ * @param initialHeaders - Headers that are already in the CloudFront format
+ *    that should be added to the result.
+ * @param headers - Header object in key-value format that should be converted
+ *    to CloudFront format. If there is a header with the same key in
+ *    `initialHeaders` this will be overridden.
+ * @returns Object with headers in CloudFront format (merged `initialHeaders`
+ *    and `headers`).
+ */
+function generateCloudFrontHeaders(
+  initialHeaders: CloudFrontHeaders,
+  headers: HTTPHeaders
+): CloudFrontHeaders {
+  const cloudFrontHeaders: CloudFrontHeaders = { ...initialHeaders };
+  for (const key in headers) {
+    const lowercaseKey = key.toLowerCase();
+    cloudFrontHeaders[lowercaseKey] = [{ key, value: headers[key] }];
+  }
+
+  return cloudFrontHeaders;
+}
+
+export { generateCloudFrontHeaders };

--- a/test/fixtures/02-api/pages/api/actions/[actionId]/info.js
+++ b/test/fixtures/02-api/pages/api/actions/[actionId]/info.js
@@ -1,4 +1,5 @@
 export default function handler(req, res) {
   const { actionId } = req.query;
+  res.setHeader('Cache-Control', 'no-cache');
   res.end(`actionId: ${actionId}`);
 }

--- a/test/fixtures/02-api/pages/api/host.js
+++ b/test/fixtures/02-api/pages/api/host.js
@@ -1,0 +1,8 @@
+/**
+ * Output the host header of the request
+ */
+
+export default function handler(req, res) {
+  const host = req.headers['host'];
+  res.end(`host: ${host}`);
+}

--- a/test/fixtures/02-api/pages/api/host.js
+++ b/test/fixtures/02-api/pages/api/host.js
@@ -4,5 +4,7 @@
 
 export default function handler(req, res) {
   const host = req.headers['host'];
+
+  res.setHeader('Cache-Control', 'no-cache');
   res.end(`host: ${host}`);
 }

--- a/test/fixtures/02-api/pages/api/index.js
+++ b/test/fixtures/02-api/pages/api/index.js
@@ -1,5 +1,6 @@
 export default function handler(req, res) {
   res.statusCode = 200;
+  res.setHeader('Cache-Control', 'no-cache');
   res.setHeader('Set-Cookie', ['cookie-1', 'cookie-2']);
   res.end(JSON.stringify({ foo: 'bar' }));
 }

--- a/test/fixtures/02-api/pages/api/viewer-header.js
+++ b/test/fixtures/02-api/pages/api/viewer-header.js
@@ -1,0 +1,8 @@
+/**
+ * prints the custom header `x-tf-next-abc`
+ */
+
+export default function handler(req, res) {
+  const headerValue = req.headers['x-tf-next-abc'];
+  res.end(`x-tf-next-abc: ${headerValue}`);
+}

--- a/test/fixtures/02-api/pages/api/viewer-header.js
+++ b/test/fixtures/02-api/pages/api/viewer-header.js
@@ -4,5 +4,6 @@
 
 export default function handler(req, res) {
   const headerValue = req.headers['x-tf-next-abc'];
+  res.setHeader('Cache-Control', 'no-cache');
   res.end(`x-tf-next-abc: ${headerValue}`);
 }

--- a/test/fixtures/02-api/pages/test.js
+++ b/test/fixtures/02-api/pages/test.js
@@ -1,0 +1,7 @@
+export default function AboutPage() {
+  return (
+    <div>
+      <h1>About</h1>
+    </div>
+  );
+}

--- a/test/fixtures/02-api/probes.json
+++ b/test/fixtures/02-api/probes.json
@@ -12,6 +12,14 @@
       "path": "/api/actions/12345/info",
       "status": 200,
       "mustContain": "actionId: 12345"
+    },
+    {
+      "path": "/api/host",
+      "requestHeaders": {
+        "Host": "example.org"
+      },
+      "status": 200,
+      "mustContain": "host: example.org"
     }
   ]
 }

--- a/test/fixtures/02-api/probes.json
+++ b/test/fixtures/02-api/probes.json
@@ -13,13 +13,23 @@
       "status": 200,
       "mustContain": "actionId: 12345"
     },
+
+    // Headers
     {
       "path": "/api/host",
       "requestHeaders": {
-        "Host": "example.org"
+        "host": "example.org"
       },
       "status": 200,
       "mustContain": "host: example.org"
+    },
+    {
+      "path": "/api/viewer-header",
+      "requestHeaders": {
+        "x-tf-next-abc": "test123"
+      },
+      "status": 200,
+      "mustContain": "x-tf-next-abc: test123"
     }
   ]
 }

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -57,6 +57,7 @@ interface ProbeFile {
     status?: number;
     statusDescription?: string;
     responseHeaders?: Record<string, string>;
+    requestHeaders?: Record<string, string>;
     destPath?: string;
   }[];
 }
@@ -239,6 +240,7 @@ describe('Test proxy config', () => {
         };
 
         proxySAM = await generateProxySAM({
+          runtime: 'nodejs14.x',
           pathToProxyPackage,
           proxyConfig: JSON.stringify(proxyConfig),
           onData(data: string) {
@@ -270,6 +272,7 @@ describe('Test proxy config', () => {
         for (const probe of probeFile.probes) {
           const Request = await proxySAM.sendRequestEvent({
             uri: probe.path,
+            headers: probe.requestHeaders,
           });
 
           if ('origin' in Request) {

--- a/variables.tf
+++ b/variables.tf
@@ -122,16 +122,16 @@ variable "cloudfront_minimum_protocol_version" {
   default     = "TLSv1"
 }
 
-variable "cloudfront_origin_headers" {
-  description = "Header keys that should be sent to the S3 or Lambda origins. Should not contain any header that is defined via cloudfront_cache_key_headers."
-  type        = list(string)
-  default     = ["X-Forwarded-Host"]
+variable "cloudfront_origin_request_policy" {
+  description = "Id of a custom request policy that overrides the default policy (AllViewer). Can be custom or managed."
+  type        = string
+  default     = null
 }
 
 variable "cloudfront_cache_key_headers" {
   description = "Header keys that should be used to calculate the cache key in CloudFront."
   type        = list(string)
-  default     = ["Authorization", "Host"]
+  default     = ["Authorization"]
 }
 
 variable "cloudfront_external_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -125,13 +125,13 @@ variable "cloudfront_minimum_protocol_version" {
 variable "cloudfront_origin_headers" {
   description = "Header keys that should be sent to the S3 or Lambda origins. Should not contain any header that is defined via cloudfront_cache_key_headers."
   type        = list(string)
-  default     = []
+  default     = ["X-Forwarded-Host"]
 }
 
 variable "cloudfront_cache_key_headers" {
   description = "Header keys that should be used to calculate the cache key in CloudFront."
   type        = list(string)
-  default     = ["Authorization"]
+  default     = ["Authorization", "Host"]
 }
 
 variable "cloudfront_external_id" {


### PR DESCRIPTION
Replaces the `host` header inside of the Lambda function with the value of `x-forwarded-host`.
Normally the `host` header would be set to the internal domain of the API Gateway endpoint which makes it impossible to get the original `host` header from the client.

## ToDo
- [x] Make sure that Host header is always overridden in Proxy (especially with S3 origin)

Fixes #156.