### PR TITLE
Fix issue where static routes are not served from S3 correctly

### DIFF
--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -112,7 +112,7 @@ export class Proxy {
             result = {
               found: true,
               target: 'filesystem',
-              dest: reqPathname,
+              dest: filePath,
               headers: combinedHeaders,
               continue: false,
               isDestUrl: false,


### PR DESCRIPTION
Due to 0.9.1 fix, the S3 serving code path is adding `/index` to the filepath where trying to serve static pages from S3

Eg. Having route "/login/" is returning 404, because the proxy tries to serve it from filepath "login/index" instead of "index"