### PR TITLE
Fixes e2e tests for Next.js 11.1.0

### DIFF
--- a/packages/node-bridge/src/bridge.ts
+++ b/packages/node-bridge/src/bridge.ts
@@ -208,6 +208,16 @@ export class Bridge {
               continue;
             }
 
+            // Is dropped by API Gateway
+            // Was added in Next.js 11.1.0
+            // We need to remove this, since the in the local e2e tests
+            // AWS SAM CLI forwards this header to the viewer, which produces
+            // an error, since `transfer-encoding` and `content-length` headers
+            // should not be present on the same response
+            if (headerKey === 'transfer-encoding') {
+              continue;
+            }
+
             // Filter out cookies
             if (headerKey === 'set-cookie' && headerValue) {
               if (typeof headerValue === 'string') {


### PR DESCRIPTION
Since Next.js the header `transfer-encoding` is added to the Lambda response.
In production this is not a problem, because API Gateway drops this header from the Response before sending it to the viewer.
However with local testing (with AWS SAM CLI) the header is not removed from the response and is therefore sent to the viewer.

This results in that both `transfer-encoding` and `content-length` headers are sent to the viewer which results in an error in node-fetch.