### PR TITLE
Provide module path to npm-download submodule

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,7 @@ module "statics_deploy" {
   tags            = var.tags
 
   debug_use_local_packages = var.debug_use_local_packages
+  tf_next_module_root      = path.module
 }
 
 # Lambda
@@ -212,6 +213,7 @@ module "proxy" {
   tags            = var.tags
 
   debug_use_local_packages = var.debug_use_local_packages
+  tf_next_module_root      = path.module
 
   providers = {
     aws.global_region = aws.global_region

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -1,11 +1,12 @@
 module "proxy_package" {
   source  = "dealmore/download/npm"
-  version = "1.0.0"
+  version = "1.1.0"
 
   module_name    = "@dealmore/terraform-next-proxy"
   module_version = var.proxy_module_version
   path_to_file   = "dist.zip"
   use_local      = var.debug_use_local_packages
+  local_cwd      = var.tf_next_module_root
 }
 
 #############

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -36,3 +36,7 @@ variable "debug_use_local_packages" {
   type    = bool
   default = false
 }
+
+variable "tf_next_module_root" {
+  type = string
+}

--- a/modules/statics-deploy/main.tf
+++ b/modules/statics-deploy/main.tf
@@ -159,12 +159,13 @@ data "aws_iam_policy_document" "access_sqs_queue" {
 
 module "lambda_content" {
   source  = "dealmore/download/npm"
-  version = "1.0.0"
+  version = "1.1.0"
 
   module_name    = "@dealmore/terraform-next-deploy-trigger"
   module_version = var.deploy_trigger_module_version
   path_to_file   = "dist.zip"
   use_local      = var.debug_use_local_packages
+  local_cwd      = var.tf_next_module_root
 }
 
 resource "random_id" "function_name" {

--- a/modules/statics-deploy/variables.tf
+++ b/modules/statics-deploy/variables.tf
@@ -63,3 +63,7 @@ variable "debug_use_local_packages" {
   type    = bool
   default = false
 }
+
+variable "tf_next_module_root" {
+  type = string
+}


### PR DESCRIPTION
This fixes an issue in local development:
When referencing a local version of the module and using the `debug_use_local_packages` option, the npm submodule would falsely try to resolve the package from the current cwd rather than from the module's root.