### PR TITLE
Multiple deployments: switch aliases

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -190,6 +190,7 @@ module "proxy_config" {
   cloudfront_price_class = var.cloudfront_price_class
   proxy_config_json      = local.proxy_config_json
   proxy_config_version   = local.config_file_version
+  multiple_deployments   = var.multiple_deployments
 
   deployment_name = var.deployment_name
   tags            = var.tags
@@ -214,6 +215,7 @@ module "proxy" {
 
   debug_use_local_packages = var.debug_use_local_packages
   tf_next_module_root      = path.module
+  proxy_config_table_arn   = module.proxy_config.table_arn
 
   providers = {
     aws.global_region = aws.global_region
@@ -260,6 +262,8 @@ resource "aws_cloudfront_origin_request_policy" "this" {
     query_string_behavior = "all"
   }
 }
+
+data "aws_region" "current" {}
 
 resource "aws_cloudfront_cache_policy" "this" {
   name    = "${random_id.policy_name.hex}-cache"
@@ -316,6 +320,14 @@ locals {
       {
         name  = "x-env-config-endpoint"
         value = "http://${module.proxy_config.config_endpoint}"
+      },
+      {
+        name  = "x-env-config-table"
+        value = module.proxy_config.table_name
+      },
+      {
+        name  = "x-env-config-region"
+        value = data.aws_region.current.name
       },
       {
         name  = "x-env-api-endpoint"

--- a/modules/cloudfront-proxy-config/main.tf
+++ b/modules/cloudfront-proxy-config/main.tf
@@ -4,6 +4,25 @@ locals {
   proxy_config_max_age = 15 * 60
 }
 
+################
+# DynamoDB Table
+################
+
+resource "aws_dynamodb_table" "proxy_config" {
+  count = var.multiple_deployments ? 1 : 0
+
+  name         = var.proxy_config_table_name
+  billing_mode = "PAY_PER_REQUEST"
+
+  # This is either the deployment id or an alias
+  hash_key = "alias"
+
+  attribute {
+    name = "alias"
+    type = "S"
+  }
+}
+
 ########
 # Bucket
 ########

--- a/modules/cloudfront-proxy-config/outputs.tf
+++ b/modules/cloudfront-proxy-config/outputs.tf
@@ -1,3 +1,11 @@
 output "config_endpoint" {
   value = "${aws_cloudfront_distribution.distribution.domain_name}/${local.proxy_config_key}"
 }
+
+output "table_arn" {
+  value = var.multiple_deployments ? aws_dynamodb_table.proxy_config[0].arn : null
+}
+
+output "table_name" {
+  value = var.multiple_deployments ? aws_dynamodb_table.proxy_config[0].name : null
+}

--- a/modules/cloudfront-proxy-config/variables.tf
+++ b/modules/cloudfront-proxy-config/variables.tf
@@ -15,6 +15,22 @@ variable "proxy_config_version" {
   }
 }
 
+################
+# DynamoDB Table
+################
+
+variable "multiple_deployments" {
+  description = "Have multiple deployments and domain aliases."
+  type        = bool
+  default     = false
+}
+
+variable "proxy_config_table_name" {
+  description = "Name of the DynamoDB table to store proxy configurations."
+  type        = string
+  default     = "tf-next-proxy-config"
+}
+
 ############
 # CloudFront
 ############

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -17,6 +17,11 @@ variable "lambda_role_permissions_boundary" {
   default = null
 }
 
+variable "proxy_config_table_arn" {
+  type    = string
+  default = null
+}
+
 ##########
 # Labeling
 ##########

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@vercel/routing-utils": "^1.9.1",
     "abort-controller": "^3.0.0",
+    "aws-sdk": "*",
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {

--- a/packages/tf-next/src/commands/delete-alias.ts
+++ b/packages/tf-next/src/commands/delete-alias.ts
@@ -1,0 +1,35 @@
+import { DynamoDB } from 'aws-sdk';
+
+const jp = require('jsonpath');
+
+const dynamoDB = new DynamoDB();
+
+interface DeleteAliasProps {
+  alias?: string;
+  terraformState: any;
+  target?: 'AWS';
+}
+
+async function deleteAliasCommand({
+  alias,
+  terraformState,
+  target = 'AWS',
+}: DeleteAliasProps) {
+  const dynamoTable = jp.query(terraformState, '$..*[?(@.type=="aws_dynamodb_table" && @.name=="proxy_config")]');
+  const proxyConfigTable = dynamoTable[0].values.name;
+
+  // Delete existing proxy config for deployment
+  const response = await dynamoDB.deleteItem({
+      TableName: proxyConfigTable,
+      Key: {
+          alias: {S: alias},
+      },
+      ReturnValues: 'ALL_OLD',
+  }).promise();
+
+  if (!response.Attributes) {
+    throw new Error(`Could not find alias ${alias}.`);
+  }
+}
+
+export default deleteAliasCommand;

--- a/packages/tf-next/src/commands/list-deployments.ts
+++ b/packages/tf-next/src/commands/list-deployments.ts
@@ -1,22 +1,52 @@
-import { ApiGatewayV2 } from 'aws-sdk';
+import { DynamoDB } from 'aws-sdk';
 
-const apiGatewayV2 = new ApiGatewayV2();
+const jp = require('jsonpath');
+
+const dynamoDB = new DynamoDB();
 
 interface ListDeploymentProps {
+  terraformState: any;
   target?: 'AWS';
 }
 
 async function listDeploymentsCommand({
+  terraformState,
   target = 'AWS',
 }: ListDeploymentProps) {
-  const apis = await apiGatewayV2.getApis().promise();
-  for (const item of apis.Items || []) {
-    if (item.Name.startsWith('tf-next') && item.Description === 'Managed by Terraform-next.js') {
-      const name = item.Name.split(' - ');
-      if (name[name.length - 1] !== 'tf-next') {
-        console.log(name[name.length - 1]);
-      }
+  const dynamoTable = jp.query(terraformState, '$..*[?(@.type=="aws_dynamodb_table" && @.name=="proxy_config")]');
+  const proxyConfigTable = dynamoTable[0].values.name;
+
+  const response = await dynamoDB.scan({
+    TableName: proxyConfigTable,
+    ProjectionExpression: "#A, #AT",
+    ExpressionAttributeNames: {
+      "#A": "alias",
+      "#AT": "aliasedTo",
+     },
+  }).promise();
+
+  const aliases = response.Items;
+
+  if (!aliases || aliases.length === 0) {
+    console.log('There are currently no deployments.');
+    return;
+  }
+
+  const deployments: any = {};
+  for (const alias of aliases) {
+    if (alias.aliasedTo?.S && alias.alias?.S) { // If this is an alias
+      deployments[alias.aliasedTo.S] = deployments[alias.aliasedTo.S] || [];
+      deployments[alias.aliasedTo.S].push(alias.alias.S);
+    } else if (alias.alias?.S) {                // If this is a deployment
+      deployments[alias.alias.S] = deployments[alias.alias.S] || [];
     }
+  }
+
+  for (const deployment of Object.keys(deployments)) {
+    const deploymentAliases = deployments[deployment] === []
+      ? '' :
+      `, aliases: [${deployments[deployment].join(', ')}]`;
+    console.log(`${deployment}${deploymentAliases}`);
   }
 }
 

--- a/packages/tf-next/src/commands/update-alias.ts
+++ b/packages/tf-next/src/commands/update-alias.ts
@@ -1,0 +1,50 @@
+import { DynamoDB } from 'aws-sdk';
+
+const jp = require('jsonpath');
+
+const dynamoDB = new DynamoDB();
+
+interface UpdateAliasProps {
+  deploymentId: string;
+  alias?: string;
+  parent: boolean;
+  terraformState: any;
+  target?: 'AWS';
+}
+
+async function updateAliasCommand({
+  deploymentId,
+  alias,
+  parent,
+  terraformState,
+  target = 'AWS',
+}: UpdateAliasProps) {
+  const dynamoTable = jp.query(terraformState, '$..*[?(@.type=="aws_dynamodb_table" && @.name=="proxy_config")]');
+  const proxyConfigTable = dynamoTable[0].values.name;
+
+  // Read existing proxy config for deployment
+  const proxyConfig = await dynamoDB.getItem({
+    TableName: proxyConfigTable,
+    Key: {
+      alias: {S: deploymentId},
+    }
+  }).promise();
+
+  if (!proxyConfig.Item?.proxyConfig) {
+    throw new Error(`Could not find existing deployment ${deploymentId}.`);
+  }
+
+  // Write new alias
+  await dynamoDB.putItem({
+    TableName: proxyConfigTable,
+    Item: {
+      alias: {
+        S: parent ? ':root:' : alias,
+      },
+      proxyConfig: proxyConfig.Item.proxyConfig,
+      aliasedTo: {S: deploymentId},
+    },
+  }).promise();
+}
+
+export default updateAliasCommand;

--- a/packages/tf-next/src/index.ts
+++ b/packages/tf-next/src/index.ts
@@ -43,7 +43,87 @@ yargs
     'list-deployments',
     'List existing deployments',
     async () => {
-      (await import('./commands/list-deployments')).default({});
+      // TODO:
+      // Figure out a good way to pass the current terraform state. Especially
+      // considering that there could be multiple environments (preview,
+      // production). For development/testing, we'll save the current state,
+      // that we get when running `$ terraform show -json` into a file called
+      // `terraform.config.json` at the root of this package.
+      const terraformState = require('../terraform.config.json');
+
+      (await import('./commands/list-deployments')).default({terraformState});
+    }
+  )
+  .command(
+    'delete-alias',
+    'Delete an alias',
+    (yargs_) => {
+      return yargs_
+        .option('alias', {
+          type: 'string',
+          description: 'The alias to delete',
+          demandOption: true,
+        });
+    },
+    async({ alias }) => {
+      // TODO:
+      // Figure out a good way to pass the current terraform state. Especially
+      // considering that there could be multiple environments (preview,
+      // production). For development/testing, we'll save the current state,
+      // that we get when running `$ terraform show -json` into a file called
+      // `terraform.config.json` at the root of this package.
+      const terraformState = require('../terraform.config.json');
+
+      await (await import('./commands/delete-alias')).default({
+        alias,
+        terraformState,
+      });
+
+      console.log(`Deleted alias ${alias}.`);
+
+    }
+  )
+  .command(
+    'update-alias',
+    'Create or update an alias for an existing deployment',
+    (yargs_) => {
+      return yargs_
+        .option('alias', {
+          type: 'string',
+          description: 'Name of the alias',
+        })
+        .option('deploymentId', {
+          type: 'string',
+          description: 'The id of the deployment to alias',
+          demandOption: true,
+        })
+        .option('parent', {
+          type: 'boolean',
+          description: 'Alias to the parent domain',
+          default: false,
+        });
+    },
+    async({ alias, deploymentId, parent }) => {
+      if (!alias && !parent || parent && alias) {
+        throw new Error('Please specify either `parent` or `alias`.');
+      }
+
+      // TODO:
+      // Figure out a good way to pass the current terraform state. Especially
+      // considering that there could be multiple environments (preview,
+      // production). For development/testing, we'll save the current state,
+      // that we get when running `$ terraform show -json` into a file called
+      // `terraform.config.json` at the root of this package.
+      const terraformState = require('../terraform.config.json');
+
+      await (await import('./commands/update-alias')).default({
+        deploymentId,
+        alias,
+        parent,
+        terraformState,
+      });
+
+      console.log(`Aliased deployment ${deploymentId} to ${parent ? 'parent domain' : alias}.`);
     }
   )
   .command(

--- a/packages/tf-next/src/types.ts
+++ b/packages/tf-next/src/types.ts
@@ -27,3 +27,11 @@ export interface ConfigOutput {
   };
   version: number;
 }
+
+export interface ProxyConfig {
+  routes: Route[];
+  lambdaRoutes: string[];
+  staticRoutes: string[];
+  prerenders: Record<string, { lambda: string }>;
+  apiId?: string;
+}

--- a/variables.tf
+++ b/variables.tf
@@ -143,13 +143,19 @@ variable "tags" {
   default     = {}
 }
 
-#####################
-# Preview Deployments
-#####################
+######################
+# Multiple Deployments
+######################
 variable "domain_name" {
   description = "This is used to figure out which preview deployment to route to."
   type        = string
   default     = null
+}
+
+variable "multiple_deployments" {
+  description = "Have multiple deployments and domain aliases."
+  type        = bool
+  default     = false
 }
 
 ################


### PR DESCRIPTION
This is the fourth PR in a series to introduce the handling of multiple parallel deployments.

What this PR does:

* Add aliases for deployments

Things left to do:

* Allow for things like tags, role boundaries, etc. to be passed on to the create-deployment command
* Remove code duplication (TF/TS)
* Documentation/an example of how to setup wildcard subdomains for this
* New architecture picture
