### PR TITLE
Replace / with /index in check for static routes

### DIFF
--- a/packages/deploy-trigger/src/handler.ts
+++ b/packages/deploy-trigger/src/handler.ts
@@ -78,7 +78,7 @@ async function createCloudFrontInvalidation(
         InvalidationBatch,
       })
       .promise();
-  } catch (err) {
+  } catch (err: any) {
     console.log(err);
     if (err.code === 'TooManyInvalidationsInProgress') {
       // Send the invalidation back to the queue

--- a/packages/node-bridge/src/bridge.ts
+++ b/packages/node-bridge/src/bridge.ts
@@ -272,7 +272,7 @@ export class Bridge {
         }
         try {
           req.setHeader(name, value);
-        } catch (err) {
+        } catch (err: any) {
           console.error(
             'Skipping HTTP request header: %j',
             `${name}: ${value}`

--- a/packages/proxy/src/__test__/proxy.unit.test.ts
+++ b/packages/proxy/src/__test__/proxy.unit.test.ts
@@ -413,15 +413,11 @@ test('[proxy-unit] static index route', () => {
 
   expect(result).toEqual({
     found: true,
-    dest: '/index.html',
+    dest: '/index',
     target: 'filesystem',
     continue: false,
     status: undefined,
     headers: {},
-    uri_args: new URLSearchParams(),
-    matched_route: routesConfig[0],
-    matched_route_idx: 0,
-    userDest: true,
     isDestUrl: false,
     phase: 'filesystem',
   });

--- a/packages/proxy/src/__test__/proxy.unit.test.ts
+++ b/packages/proxy/src/__test__/proxy.unit.test.ts
@@ -402,3 +402,27 @@ test('[proxy-unit] i18n default locale', () => {
     target: undefined,
   });
 });
+
+test('[proxy-unit] static index route', () => {
+  const routesConfig = [
+    {
+      handle: 'filesystem' as const,
+    },
+  ];
+  const result = new Proxy(routesConfig, [], ['/index']).route('/');
+
+  expect(result).toEqual({
+    found: true,
+    dest: '/index.html',
+    target: 'filesystem',
+    continue: false,
+    status: undefined,
+    headers: {},
+    uri_args: new URLSearchParams(),
+    matched_route: routesConfig[0],
+    matched_route_idx: 0,
+    userDest: true,
+    isDestUrl: false,
+    phase: 'filesystem',
+  });
+});

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -104,19 +104,20 @@ export class Proxy {
         // Check if the path is a static file that should be served from the
         // filesystem
         if (routeConfig.handle === 'filesystem') {
-          // Remove tailing `/` for filesystem check
-          const filePath = reqPathname.replace(/\/+$/, '');
+          // Replace tailing `/` with `/index`
+          const filePath = reqPathname.replace(/\/$/, '/index');
 
           // Check if the route matches a route from the filesystem
           if (this._checkFileSystem(filePath)) {
             result = {
               found: true,
               target: 'filesystem',
-              dest: reqPathname,
+              dest: filePath,
               headers: combinedHeaders,
               continue: false,
               isDestUrl: false,
               status,
+              phase,
             };
             break;
           }

--- a/packages/proxy/src/util/fetch-timeout.ts
+++ b/packages/proxy/src/util/fetch-timeout.ts
@@ -18,7 +18,7 @@ export async function fetchTimeout(timeout: number, url: string) {
 
   try {
     fetchResponse = await fetch(url, { signal: controller.signal });
-  } catch (err) {
+  } catch (err: any) {
     if (err.name === 'AbortError') {
       error = new Error(`Timeout while fetching config from ${url}`);
     } else {

--- a/test/fixtures/01-custom-routing/pages/index.js
+++ b/test/fixtures/01-custom-routing/pages/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+// eslint-disable-next-line camelcase
+export async function getStaticProps() {
+  return {
+    props: {
+      world: 'world',
+      path: process.cwd(),
+    },
+  };
+}
+
+export default ({ world, path }) => {
+  const isSSR = path.startsWith('/var/task/');
+
+  return (
+    <>
+      <p>hello: {world}</p>
+      <p>isSSR: {JSON.stringify(isSSR)}</p>
+    </>
+  );
+};

--- a/test/fixtures/01-custom-routing/probes.json
+++ b/test/fixtures/01-custom-routing/probes.json
@@ -40,6 +40,11 @@
       "responseHeaders": {
         "location": "/hello"
       }
+    },
+    {
+      "path": "/",
+      "status": 200,
+      "mustContain": "isSSR: <!-- -->false"
     }
   ]
 }


### PR DESCRIPTION
This replaces the path with a trailing slash (`/`) with `/index` when looking in the filesystem for a matching route.

Fixes #180.