### PR TITLE
Proxy: Fix rewrite to api route

### DIFF
--- a/test/fixtures/02-api/next.config.js
+++ b/test/fixtures/02-api/next.config.js
@@ -2,4 +2,13 @@ module.exports = {
   generateBuildId() {
     return 'testing-build-id';
   },
+
+  async rewrites() {
+    return [
+      {
+        source: '/sitemap/:type.xml',
+        destination: '/api/sitemap/:type',
+      },
+    ];
+  },
 };

--- a/test/fixtures/02-api/pages/api/sitemap/pages.js
+++ b/test/fixtures/02-api/pages/api/sitemap/pages.js
@@ -1,6 +1,5 @@
 export default function handler(_req, res) {
   res.statusCode = 200;
   res.setHeader('Content-Type', 'application/xml');
-
-  return `<?xml version="1.0" encoding="UTF-8"?><hello>world</hello>`;
+  res.end(`<?xml version="1.0" encoding="UTF-8"?><hello>world</hello>`);
 }

--- a/test/fixtures/02-api/pages/api/sitemap/pages.js
+++ b/test/fixtures/02-api/pages/api/sitemap/pages.js
@@ -1,0 +1,6 @@
+export default function handler(_req, res) {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/xml');
+
+  return `<?xml version="1.0" encoding="UTF-8"?><hello>world</hello>`;
+}

--- a/test/fixtures/02-api/probes.json
+++ b/test/fixtures/02-api/probes.json
@@ -1,17 +1,22 @@
 {
   "builds": [{ "src": "package.json", "use": "tf-next" }],
   "probes": [
+    // {
+    //   "path": "/api",
+    //   "status": 200,
+    //   "responseHeaders": {
+    //     "Set-Cookie": "cookie-1, cookie-2"
+    //   }
+    // },
+    // {
+    //   "path": "/api/actions/12345/info",
+    //   "status": 200,
+    //   "mustContain": "actionId: 12345"
+    // },
     {
-      "path": "/api",
+      "path": "/sitemap/pages.xml",
       "status": 200,
-      "responseHeaders": {
-        "Set-Cookie": "cookie-1, cookie-2"
-      }
-    },
-    {
-      "path": "/api/actions/12345/info",
-      "status": 200,
-      "mustContain": "actionId: 12345"
+      "mustContain": "<hello>world</hello>"
     }
   ]
 }


### PR DESCRIPTION
When a rewrite to an API-page (e.g. `/sitemap/test.xml` -> `/api/sitemap/test`) is added to the `next.config.js` the response results in an error.

This PR fixes this misbehavior.