### PR TITLE
fix(proxy): Invalid count argument by var.proxy_config_table_arn

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -324,7 +324,7 @@ locals {
       },
       {
         name  = "x-env-config-table"
-        value = module.proxy_config.table_name
+        value = var.multiple_deployments ? module.proxy_config.table_name : ""
       },
       {
         name  = "x-env-config-region"

--- a/main.tf
+++ b/main.tf
@@ -215,6 +215,7 @@ module "proxy" {
 
   debug_use_local_packages = var.debug_use_local_packages
   tf_next_module_root      = path.module
+  multiple_deployments     = var.multiple_deployments
   proxy_config_table_arn   = module.proxy_config.table_arn
 
   providers = {

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -36,8 +36,8 @@ module "edge_proxy" {
   handler                   = "handler.handler"
   runtime                   = var.lambda_default_runtime
   role_permissions_boundary = var.lambda_role_permissions_boundary
-  policy_json               = var.proxy_config_table_arn != null ? data.aws_iam_policy_document.dynamo_access.json : null
-  attach_policy_json        = var.proxy_config_table_arn != null
+  policy_json               = var.multiple_deployments ? data.aws_iam_policy_document.dynamo_access.json : null
+  attach_policy_json        = var.multiple_deployments
 
   create_package         = false
   local_existing_package = module.proxy_package.abs_path

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -19,6 +19,7 @@ resource "random_id" "function_name" {
 }
 
 data "aws_iam_policy_document" "dynamo_access" {
+  count = var.multiple_deployments ? 1 : 0
   statement {
     actions   = ["dynamodb:GetItem"]
     resources = [var.proxy_config_table_arn]
@@ -36,7 +37,7 @@ module "edge_proxy" {
   handler                   = "handler.handler"
   runtime                   = var.lambda_default_runtime
   role_permissions_boundary = var.lambda_role_permissions_boundary
-  policy_json               = var.multiple_deployments ? data.aws_iam_policy_document.dynamo_access.json : null
+  policy_json               = var.multiple_deployments ? data.aws_iam_policy_document.dynamo_access[0].json : null
   attach_policy_json        = var.multiple_deployments
 
   create_package         = false

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -22,6 +22,11 @@ variable "proxy_config_table_arn" {
   default = null
 }
 
+variable "multiple_deployments" {
+  type    = bool
+  default = false
+}
+
 ##########
 # Labeling
 ##########


### PR DESCRIPTION
- fix #184 when using `var.multiple_deployments = true`
- pass additional `var.multiple_deployments` variable into root module -> `proxy` module -> `edge_proxy` module