### PR TITLE
Extend deploy trigger to do the actual infra creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,10 @@
 locals {
   # next-tf config
-  config_dir           = trimsuffix(var.next_tf_dir, "/")
-  config_file          = jsondecode(file("${local.config_dir}/config.json"))
-  lambdas              = lookup(local.config_file, "lambdas", {})
-  static_files_archive = "${local.config_dir}/${lookup(local.config_file, "staticFilesArchive", "")}"
+  config_dir                = trimsuffix(var.next_tf_dir, "/")
+  config_file               = jsondecode(file("${local.config_dir}/config.json"))
+  lambdas                   = lookup(local.config_file, "lambdas", {})
+  static_files_archive_name = lookup(local.config_file, "staticFilesArchive", "")
+  static_files_archive      = "${local.config_dir}/${local.static_files_archive_name}"
 
   # Build the proxy config JSON
   config_file_images  = lookup(local.config_file, "images", {})
@@ -40,8 +41,19 @@ resource "random_id" "function_name" {
 module "statics_deploy" {
   source = "./modules/statics-deploy"
 
-  static_files_archive = local.static_files_archive
-  expire_static_assets = var.expire_static_assets
+  expire_static_assets         = var.expire_static_assets
+  static_files_archive         = local.static_files_archive
+  static_files_archive_name    = local.static_files_archive_name
+  lambda_logging_policy_arn    = aws_iam_policy.lambda_logging.arn
+  lambda_attach_to_vpc         = var.lambda_attach_to_vpc
+  lambda_environment_variables = var.lambda_environment_variables
+  multiple_deployments         = var.multiple_deployments
+  proxy_config_table_name      = module.proxy_config.table_name
+  proxy_config_table_arn       = module.proxy_config.table_arn
+  proxy_config_bucket_name     = module.proxy_config.bucket_name
+  proxy_config_bucket_arn      = module.proxy_config.bucket_arn
+  vpc_security_group_ids       = var.vpc_security_group_ids
+  vpc_subnet_ids               = var.vpc_subnet_ids
 
   cloudfront_id  = var.cloudfront_create_distribution ? module.cloudfront_main[0].cloudfront_id : var.cloudfront_external_id
   cloudfront_arn = var.cloudfront_create_distribution ? module.cloudfront_main[0].cloudfront_arn : var.cloudfront_external_arn

--- a/modules/cloudfront-proxy-config/outputs.tf
+++ b/modules/cloudfront-proxy-config/outputs.tf
@@ -9,3 +9,11 @@ output "table_arn" {
 output "table_name" {
   value = var.multiple_deployments ? aws_dynamodb_table.proxy_config[0].name : null
 }
+
+output "bucket_name" {
+  value = aws_s3_bucket.proxy_config_store.id
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.proxy_config_store.arn
+}

--- a/modules/statics-deploy/main.tf
+++ b/modules/statics-deploy/main.tf
@@ -1,7 +1,10 @@
 locals {
   manifest_key   = "_tf-next/deployment.json"
   lambda_timeout = 60
+  account_id     = data.aws_caller_identity.current.account_id
 }
+
+data "aws_caller_identity" "current" {}
 
 ########################
 # Upload Bucket (zipped)
@@ -157,6 +160,40 @@ data "aws_iam_policy_document" "access_sqs_queue" {
   }
 }
 
+#
+# Lambda permissions to create deployment
+#
+data "aws_iam_policy_document" "create_deployment" {
+  count = var.multiple_deployments ? 1 : 0
+
+  statement {
+    actions = [
+      "apigateway:POST",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeVpcs",
+      "iam:AttachRolePolicy",
+      "iam:CreateRole",
+      "iam:PassRole",
+      "lambda:AddPermission",
+      "lambda:CreateFunction",
+      "logs:CreateLogGroup",
+      "logs:PutRetentionPolicy"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    actions   = ["s3:PutObject"]
+    resources = ["${var.proxy_config_bucket_arn}/*"]
+  }
+
+  statement {
+    actions   = ["dynamodb:PutItem"]
+    resources = [var.proxy_config_table_arn]
+  }
+}
+
 module "lambda_content" {
   source  = "milliHQ/download/npm"
   version = "2.0.0"
@@ -207,19 +244,35 @@ module "deploy_trigger" {
   }
 
   attach_policy_jsons    = true
-  number_of_policy_jsons = 3
-  policy_jsons = [
+  number_of_policy_jsons = var.multiple_deployments ? 4 : 3
+  policy_jsons = var.multiple_deployments ? [
+    data.aws_iam_policy_document.access_static_deploy.json,
+    data.aws_iam_policy_document.access_static_upload.json,
+    data.aws_iam_policy_document.access_sqs_queue.json,
+    data.aws_iam_policy_document.create_deployment[0].json
+    ] : [
     data.aws_iam_policy_document.access_static_deploy.json,
     data.aws_iam_policy_document.access_static_upload.json,
     data.aws_iam_policy_document.access_sqs_queue.json
   ]
 
   environment_variables = {
-    NODE_ENV          = "production"
-    TARGET_BUCKET     = aws_s3_bucket.static_deploy.id
-    EXPIRE_AFTER_DAYS = var.expire_static_assets >= 0 ? var.expire_static_assets : "never"
-    DISTRIBUTION_ID   = var.cloudfront_id
-    SQS_QUEUE_URL     = aws_sqs_queue.this.id
+    NODE_ENV                     = "production"
+    TARGET_BUCKET                = aws_s3_bucket.static_deploy.id
+    EXPIRE_AFTER_DAYS            = var.expire_static_assets >= 0 ? var.expire_static_assets : "never"
+    DISTRIBUTION_ID              = var.cloudfront_id
+    SQS_QUEUE_URL                = aws_sqs_queue.this.id
+    STATIC_FILES_ARCHIVE         = var.static_files_archive_name
+    DEPLOYMENT_FILE              = "deployment.zip"
+    ATTACH_TO_VPC                = var.lambda_attach_to_vpc
+    VPC_SECURITY_GROUP_IDS       = jsonencode(var.vpc_security_group_ids)
+    VPC_SUBNET_IDS               = jsonencode(var.vpc_subnet_ids)
+    LAMBDA_ENVIRONMENT_VARIABLES = jsonencode(var.lambda_environment_variables)
+    ACCOUNT_ID                   = local.account_id
+    LAMBDA_LOGGING_POLICY_ARN    = var.lambda_logging_policy_arn
+    PROXY_CONFIG_BUCKET          = var.proxy_config_bucket_name
+    PROXY_CONFIG_TABLE           = var.proxy_config_table_name
+    REGION                       = aws_s3_bucket.static_upload.region
   }
 
   event_source_mapping = {

--- a/modules/statics-deploy/variables.tf
+++ b/modules/statics-deploy/variables.tf
@@ -2,6 +2,10 @@ variable "static_files_archive" {
   type = string
 }
 
+variable "static_files_archive_name" {
+  type = string
+}
+
 variable "deploy_trigger_module_version" {
   type    = string
   default = "0.4.0"
@@ -31,6 +35,12 @@ variable "use_awscli_for_static_upload" {
   default = false
 }
 
+variable "multiple_deployments" {
+  description = "Have multiple deployments and domain aliases."
+  type        = bool
+  default     = false
+}
+
 ###########
 # SQS Queue
 ###########
@@ -54,6 +64,60 @@ variable "deployment_name" {
 variable "tags" {
   type    = map(string)
   default = {}
+}
+
+#####################
+# Deployment creation
+#####################
+variable "lambda_attach_to_vpc" {
+  type        = bool
+  description = "Set to true if the Lambda functions should be attached to a VPC. Use this setting if VPC resources should be accessed by the Lambda functions. When setting this to true, use vpc_security_group_ids and vpc_subnet_ids to specify the VPC networking. Note that attaching to a VPC would introduce a delay on to cold starts"
+  default     = false
+}
+
+variable "vpc_subnet_ids" {
+  type        = list(string)
+  description = "The list of VPC subnet IDs to attach the Lambda functions. lambda_attach_to_vpc should be set to true for these to be applied."
+  default     = []
+}
+
+variable "vpc_security_group_ids" {
+  type        = list(string)
+  description = "The list of Security Group IDs to be used by the Lambda functions. lambda_attach_to_vpc should be set to true for these to be applied."
+  default     = []
+}
+
+variable "lambda_environment_variables" {
+  type        = map(string)
+  description = "Map that defines environment variables for the Lambda Functions in Next.js."
+  default     = {}
+}
+
+variable "proxy_config_table_name" {
+  description = "Name of the DynamoDB table to store proxy configurations."
+  type        = string
+  default     = "tf-next-proxy-config"
+}
+
+variable "proxy_config_table_arn" {
+  description = "ARN of the DynamoDB table to store proxy configurations."
+  type        = string
+}
+
+variable "proxy_config_bucket_name" {
+  description = "Name of the S3 bucket to store proxy configurations."
+  type        = string
+  default     = "next-tf-proxy-config"
+}
+
+variable "proxy_config_bucket_arn" {
+  description = "ARN of the S3 bucket to store proxy configurations."
+  type        = string
+}
+
+variable "lambda_logging_policy_arn" {
+  description = "ARN of the lambda logging policy."
+  type        = string
 }
 
 #######

--- a/packages/deploy-trigger/src/create-deployment.ts
+++ b/packages/deploy-trigger/src/create-deployment.ts
@@ -1,0 +1,337 @@
+import { ApiGatewayV2, CloudWatchLogs, DynamoDB, IAM, Lambda, S3 } from 'aws-sdk';
+import { inspect } from 'util';
+import { CreateDeploymentConfiguration, Lambdas, ProxyConfig } from './types';
+
+// TODO: Have a central configuration for AWS API versions
+
+const apiGatewayV2 = new ApiGatewayV2();
+const cloudWatch = new CloudWatchLogs();
+const dynamoDB = new DynamoDB();
+const iam = new IAM();
+const lambda = new Lambda();
+const s3 = new S3();
+
+interface CreateDeploymentProps {
+  deploymentId: string;
+  lambdas: Lambdas;
+  config: CreateDeploymentConfiguration;
+  configFile: any;
+}
+
+type LambdaConfigurations = {[key: string]: LambdaConfiguration};
+
+interface LambdaConfiguration {
+  handler: string;
+  runtime: string;
+  filename: string;
+  route: string;
+  memory?: number;
+}
+
+type LambdaArns = {[key: string]: string};
+type RoleArns = {[key: string]: string};
+
+const assumeRolePolicy = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}`;
+
+async function wait(ms: number): Promise<void> {
+  return new Promise((resolve, _) => {
+    setTimeout(() => { resolve(); }, ms);
+  });
+}
+
+async function createIAM(
+  deploymentId: string,
+  lambdaConfigurations: LambdaConfigurations,
+  config: CreateDeploymentConfiguration,
+): Promise<RoleArns> {
+  const roleArns: RoleArns = {};
+
+  for (const key in lambdaConfigurations) {
+    const functionName = `${key}-${deploymentId}`;
+
+    const role = await iam.createRole({
+      AssumeRolePolicyDocument: assumeRolePolicy,
+      RoleName: functionName,
+      Description: 'Managed by Terraform Next.js',
+      Tags: [],
+    }).promise();
+    roleArns[key] = role.Role.Arn;
+
+    const logGroupName = `/aws/lambda/${functionName}`;
+
+    await cloudWatch.createLogGroup({
+      logGroupName,
+    }).promise();
+
+    await cloudWatch.putRetentionPolicy({
+      logGroupName,
+      retentionInDays: 14,
+    }).promise();
+
+    await iam.attachRolePolicy({
+      PolicyArn: config.lambdaLoggingPolicyArn,
+      RoleName: functionName,
+    }).promise();
+
+    if (config.lambdaAttachToVpc) {
+      await iam.attachRolePolicy({
+        PolicyArn: 'arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole',
+        RoleName: functionName,
+      }).promise();
+    }
+  }
+
+  // We wait for 6s, because trying to use the roles too quickly after deleting them
+  // can lead to an `InvalidParameterValueException` with the message
+  // `The role defined for the function cannot be assumed by Lambda`.
+  await wait(6000);
+
+  return roleArns;
+}
+
+async function createLambdas(
+  deploymentId: string,
+  lambdas: Lambdas,
+  lambdaConfigurations: LambdaConfigurations,
+  roleArns: RoleArns,
+  config: CreateDeploymentConfiguration,
+): Promise<LambdaArns> {
+  const arns: LambdaArns = {};
+
+  console.log('createLambdas', Object.keys(lambdaConfigurations), lambdas);
+
+  for (const key in lambdaConfigurations) {
+    // TODO: An alternative approach would be to upload the lambdas as separate zip files
+    //       and then upload the `config.json`, which would trigger the deployment creation.
+    //       Then we could use `Code: {S3Bucket, S3Key}` here instead of having to read the
+    //       lambda code explicitly.
+    //
+    const lambdaKey = Object.keys(lambdas).find((k) => k.includes(key));
+
+    if (!lambdaKey) {
+      throw new Error(`Could not find code for ${key} in ${inspect(lambdas)}`);
+    }
+
+    const fileContent = lambdas[lambdaKey];
+    const params: Lambda.Types.CreateFunctionRequest = {
+      Code: {
+        ZipFile: fileContent,
+      },
+      FunctionName: `${key}-${deploymentId}`,
+      Role: roleArns[key]!, // We know this exists, because we created it in `createIAM`
+      Description: 'Managed by Terraform-next.js',
+      Environment: {
+        Variables: config.lambdaEnvironmentVariables,
+      },
+      Handler: lambdaConfigurations[key]?.handler || '',
+      MemorySize: lambdaConfigurations[key]?.memory || config.defaultFunctionMemory,
+      PackageType: 'Zip', // Default in TF
+      Publish: false, // Default in TF
+      Runtime: lambdaConfigurations[key]?.runtime || config.defaultRuntime,
+      Tags: {},
+      Timeout: config.lambdaTimeout,
+      VpcConfig: {},
+    };
+    if (config.lambdaAttachToVpc) {
+      params.VpcConfig!.SecurityGroupIds = config.vpcSecurityGroupIds;
+      params.VpcConfig!.SubnetIds = config.vpcSubnetIds;
+    }
+    const createdLambda = await lambda.createFunction(params).promise();
+
+    if (createdLambda.FunctionArn) {
+      arns[key] = createdLambda.FunctionArn;
+    } else {
+      throw new Error(`Created lambda does not have arn: ${inspect(createdLambda)}`);
+    }
+  }
+
+  return arns;
+}
+
+async function createAPIGateway(
+  deploymentId: string,
+  lambdaConfigurations: LambdaConfigurations,
+  lambdaArns: LambdaArns,
+  config: CreateDeploymentConfiguration,
+): Promise<{ apiId: string, executeArn: string }> {
+  const api = await apiGatewayV2.createApi({
+    Name: `${config.deploymentName} - ${deploymentId}`,
+    ProtocolType: 'HTTP',
+    ApiKeySelectionExpression: '$request.header.x-api-key',
+    Description: 'Managed by Terraform-next.js',
+    RouteSelectionExpression: '$request.method $request.path',
+    Tags: {},
+  }).promise();
+
+  if (api.ApiId === undefined) {
+    throw new Error(`Created API gateway does not have an id: ${inspect(api)}`);
+  }
+
+  const stage = await apiGatewayV2.createStage({
+    ApiId: api.ApiId,
+    StageName: '$default',
+    AutoDeploy: true,
+    Description: 'Managed by Terraform-next.js',
+  }).promise();
+
+  for (const key in lambdaConfigurations) {
+    const integration = await apiGatewayV2.createIntegration({
+      ApiId: api.ApiId,
+      IntegrationType: 'AWS_PROXY',
+      Description: 'Managed by Terraform-next.js',
+      IntegrationMethod: 'POST',
+      IntegrationUri: lambdaArns[key],
+      PayloadFormatVersion: '2.0',
+      TimeoutInMillis: config.lambdaTimeout * 1000,
+    }).promise();
+
+    await apiGatewayV2.createRoute({
+      ApiId: api.ApiId,
+      RouteKey: `ANY ${lambdaConfigurations[key]?.route}/{proxy+}`,
+      AuthorizationType: 'NONE',
+      Target: `integrations/${integration.IntegrationId}`,
+    }).promise();
+  }
+
+  // The ARN prefix to be used in an aws_lambda_permission's source_arn attribute or in an aws_iam_policy to authorize access to the @connections API.
+  return {
+    apiId: api.ApiId,
+    executeArn: `arn:aws:execute-api:${config.region}:${config.accountId}:${api.ApiId}`,
+  };
+}
+
+async function createLambdaPermissions(
+  deploymentId: string,
+  lambdaConfigurations: LambdaConfigurations,
+  executeArn: string,
+) {
+  for (const key in lambdaConfigurations) {
+    await lambda.addPermission({
+      Action: 'lambda:InvokeFunction',
+      FunctionName: `${key}-${deploymentId}`,
+      Principal: 'apigateway.amazonaws.com',
+      StatementId: 'AllowInvokeFromApiGateway',
+      SourceArn: `${executeArn}/*/*/*`,
+    }).promise();
+  }
+}
+
+async function uploadProxyConfig(
+  deploymentId: string,
+  config: ProxyConfig,
+  bucket: string,
+  table: string,
+) {
+  const configString = JSON.stringify(config);
+
+  await s3.putObject({
+    Body: configString,
+    Bucket: bucket,
+    ContentType: 'application/json',
+    Key: `${deploymentId}/proxy-config.json`,
+  }).promise();
+
+  await dynamoDB.putItem({
+    TableName: table,
+    Item: {
+      alias: {
+        S: deploymentId,
+      },
+      proxyConfig: {
+        S: configString,
+      },
+    },
+  }).promise();
+}
+
+function log(deploymentId: string, message: string) {
+  console.log(`Deployment ${deploymentId}: ${message}`);
+}
+
+async function createDeployment({
+  deploymentId,
+  lambdas,
+  config,
+  configFile,
+}: CreateDeploymentProps) {
+  const lambdaConfigurations = configFile.lambdas;
+
+  log(deploymentId, 'starting to create deployment.');
+
+  // Create IAM & CW resources
+  const roleArns = await createIAM(
+    deploymentId,
+    lambdaConfigurations,
+    config,
+  );
+
+  log(deploymentId, 'created log groups and roles.');
+
+  // Create lambdas
+  const lambdaArns = await createLambdas(
+    deploymentId,
+    lambdas,
+    lambdaConfigurations,
+    roleArns,
+    config,
+  );
+
+  log(deploymentId, 'created lambda functions.');
+
+  // Create API Gateway
+  const { apiId, executeArn } = await createAPIGateway(
+    deploymentId,
+    lambdaConfigurations,
+    lambdaArns,
+    config,
+  );
+
+  log(deploymentId, 'created API gateway.');
+
+  // Create lambda permissions
+  await createLambdaPermissions(
+    deploymentId,
+    lambdaConfigurations,
+    executeArn,
+  );
+
+  log(deploymentId, 'created lambda permissions.');
+
+  // Modify proxy config to include API Gateway id and match expected format
+  const lambdaRoutes = [];
+  for (const key in lambdaConfigurations) {
+    lambdaRoutes.push(lambdaConfigurations[key].route || '/');
+  }
+
+  const modifiedProxyConfig: ProxyConfig = {
+    apiId,
+    routes: configFile.routes,
+    prerenders: configFile.prerenders,
+    staticRoutes: configFile.staticRoutes,
+    lambdaRoutes,
+  };
+
+  // Upload proxy config to bucket
+  await uploadProxyConfig(
+    deploymentId,
+    modifiedProxyConfig,
+    config.proxyConfigBucket,
+    config.proxyConfigTable,
+  );
+
+  log(deploymentId, 'created proxy config.');
+}
+
+export default createDeployment;

--- a/packages/deploy-trigger/src/types.ts
+++ b/packages/deploy-trigger/src/types.ts
@@ -1,3 +1,6 @@
+import { Lambda } from 'aws-sdk';
+import { Route } from '@vercel/routing-utils';
+
 export type ExpireValue = number | 'never';
 
 export interface ManifestFile {
@@ -16,4 +19,36 @@ export interface Manifest {
 export interface FileResult {
   key: string;
   eTag: string;
+}
+
+export interface ProxyConfig {
+  routes: Route[];
+  lambdaRoutes: string[];
+  staticRoutes: string[];
+  prerenders: Record<string, { lambda: string }>;
+  apiId?: string;
+}
+
+export type Lambdas = {[path: string]: Buffer}
+
+export interface CreateDeploymentConfiguration {
+  accountId: string;
+  defaultRuntime: string;
+  defaultFunctionMemory: number;
+  deploymentName: string;
+  lambdaAttachToVpc: boolean;
+  lambdaEnvironmentVariables: Lambda.EnvironmentVariables;
+  lambdaLoggingPolicyArn: string;
+  lambdaTimeout: number;
+  proxyConfigBucket: string;
+  proxyConfigTable: string;
+  region: string;
+  vpcSecurityGroupIds: string[];
+  vpcSubnetIds: string[];
+}
+
+export interface VpcConfig {
+  attachToVpc: boolean;
+  vpcSecurityGroupIds: string[];
+  vpcSubnetIds: string[];
 }

--- a/packages/deploy-trigger/src/utils.ts
+++ b/packages/deploy-trigger/src/utils.ts
@@ -1,4 +1,7 @@
 import { pseudoRandomBytes } from 'crypto';
+import { inspect } from 'util';
+import unzipper from 'unzipper';
+import { CreateDeploymentConfiguration, Lambdas, VpcConfig } from './types';
 
 export function generateRandomId(length: number) {
   return pseudoRandomBytes(length).toString('hex');
@@ -6,4 +9,93 @@ export function generateRandomId(length: number) {
 
 export function generateRandomBuildId() {
   return generateRandomId(16);
+}
+
+export async function readConfigFile(
+  files: unzipper.File[],
+  key: string,
+): Promise<any> {
+  const configFile = files.find((file) => file.path === 'config.json');
+  if (!configFile) {
+    throw new Error(`Did not find config.json in deployment file: ${key}`);
+  }
+
+  try {
+    const configFileContent = await configFile.buffer();
+    return JSON.parse(configFileContent.toString());
+  } catch (err) {
+    console.error(`Could not parse config.json: ${inspect(err)}`);
+    throw err;
+  }
+}
+
+export async function readLambdas(files: unzipper.File[]): Promise<Lambdas> {
+  const lambdas: Lambdas = {};
+
+  for (const file of files) {
+    if (file.path.startsWith('lambdas/')) {
+      lambdas[file.path] = await file.buffer();
+    }
+  }
+
+  return lambdas;
+}
+
+function readVpcConfig(): VpcConfig {
+  const attachToVpc = !!process.env.ATTACH_TO_VPC;
+  let vpcSecurityGroupIds = process.env.VPC_SECURITY_GROUP_IDS || '[]';
+  let vpcSubnetIds = process.env.VPC_SUBNET_IDS || '[]';
+
+  try {
+    return {
+      attachToVpc,
+      vpcSecurityGroupIds: JSON.parse(vpcSecurityGroupIds),
+      vpcSubnetIds: JSON.parse(vpcSubnetIds),
+    };
+  } catch (err) {
+    throw new Error(`Could not parse some of the VPC environment variables: ${inspect(err)}`);
+  }
+}
+
+function readLambdaEnvironmentVariables(): {[key: string]: string} {
+  const lambdaEnvironmentVariables = process.env.LAMBDA_ENVIRONMENT_VARIABLES || '{}';
+
+  try {
+    return JSON.parse(lambdaEnvironmentVariables);
+  } catch (err) {
+    throw new Error(`Could not parse lambda environment variables: ${inspect(err)}`);
+  }
+}
+
+export function readEnvConfig(): CreateDeploymentConfiguration {
+  const accountId = process.env.ACCOUNT_ID;
+  const lambdaEnvironmentVariables = readLambdaEnvironmentVariables();
+  const lambdaLoggingPolicyArn = process.env.LAMBDA_LOGGING_POLICY_ARN;
+  const proxyConfigBucket = process.env.PROXY_CONFIG_BUCKET;
+  const proxyConfigTable = process.env.PROXY_CONFIG_TABLE;
+  const region = process.env.REGION;
+  const vpcConfig = readVpcConfig();
+
+  if (!accountId || !proxyConfigTable || !proxyConfigBucket ||
+    !region || !lambdaLoggingPolicyArn) {
+    throw new Error(
+      'The environment variables do not contain all necessary information to create a deployment'
+    );
+  }
+
+  return {
+    accountId,
+    defaultFunctionMemory: 1024,
+    defaultRuntime: 'nodejs14.x',
+    deploymentName: 'tf-next',
+    lambdaAttachToVpc: vpcConfig.attachToVpc,
+    lambdaEnvironmentVariables,
+    lambdaLoggingPolicyArn,
+    lambdaTimeout: 10,
+    proxyConfigBucket,
+    proxyConfigTable,
+    region,
+    vpcSecurityGroupIds: vpcConfig.vpcSecurityGroupIds,
+    vpcSubnetIds: vpcConfig.vpcSubnetIds,
+  };
 }

--- a/packages/tf-next/src/commands/create-deployment.ts
+++ b/packages/tf-next/src/commands/create-deployment.ts
@@ -1,16 +1,7 @@
-import { ApiGatewayV2, CloudWatchLogs, DynamoDB, IAM, Lambda, S3 } from 'aws-sdk';
+import { S3 } from 'aws-sdk';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { inspect } from 'util';
-import { ProxyConfig } from '../types';
 
-const jp = require('jsonpath');
-
-const apiGatewayV2 = new ApiGatewayV2();
-const cloudWatch = new CloudWatchLogs();
-const dynamoDB = new DynamoDB();
-const iam = new IAM();
-const lambda = new Lambda();
 const s3 = new S3();
 
 type LogLevel = 'verbose' | 'none' | undefined;
@@ -19,309 +10,10 @@ interface CreateDeploymentProps {
   deploymentId: string;
   logLevel: LogLevel;
   cwd: string;
+  deploymentArchive: string;
   staticFilesArchive: string;
-  terraformState: any;
+  deployBucket: string;
   target?: 'AWS';
-}
-
-interface CreateDeploymentConfiguration {
-  accountId: string;
-  defaultRuntime: string;
-  defaultFunctionMemory: number;
-  deploymentName: string;
-  lambdaAttachToVpc: boolean;
-  lambdaEnvironmentVariables: Lambda.EnvironmentVariables;
-  lambdaLoggingPolicyArn: string;
-  lambdaTimeout: number;
-  proxyConfigBucket: string;
-  proxyConfigTable: string;
-  region: string;
-  staticDeployBucket: string;
-  vpcSecurityGroupIds: string[];
-  vpcSubnetIds: string[];
-}
-
-type LambdaConfigurations = {[key: string]: LambdaConfiguration};
-
-interface LambdaConfiguration {
-  handler: string;
-  runtime: string;
-  filename: string;
-  route: string;
-  memory?: number;
-}
-
-type LambdaArns = {[key: string]: string};
-type RoleArns = {[key: string]: string};
-
-const assumeRolePolicy = `{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}`;
-
-// In the future this will be read from environment variables attached to the
-// deploy-trigger configuration.
-async function readConfig(terraformState: any): Promise<CreateDeploymentConfiguration> {
-  const lambdaLoggingPolicy = jp.query(terraformState, '$..*[?(@.type=="aws_iam_policy" && @.name=="lambda_logging")]');
-  const existingFunction = jp.query(terraformState, '$..*[?(@.type=="aws_lambda_function" && @.index=="__NEXT_PAGE_LAMBDA_0")]');
-  const snsTopics = jp.query(terraformState, '$..*[?(@.type=="aws_sns_topic" && @.name=="this")]');
-  const proxyConfigStore = jp.query(terraformState, '$..*[?(@.type=="aws_s3_bucket" && @.name=="proxy_config_store")]');
-  const staticDeploy = jp.query(terraformState, '$..*[?(@.type=="aws_s3_bucket" && @.name=="static_upload")]');
-  const proxyConfigTable = jp.query(terraformState, '$..*[?(@.type=="aws_dynamodb_table" && @.name=="proxy_config")]');
-
-  if (lambdaLoggingPolicy.length === 0 || existingFunction.length === 0 || snsTopics.length === 0
-    || proxyConfigStore.length === 0 || staticDeploy.length === 0) {
-    throw new Error('Please first run `terraform apply` before trying to create deployments via `tf-next create-deployment`.');
-  }
-
-  const snsTopic = snsTopics.find((topic: any) => topic.values.arn.includes('tf-next'));
-
-  if (!snsTopic) {
-    throw new Error(`Could not find SNS topic created by tf-next.`);
-  }
-
-  const topicArn = snsTopic.values.arn.split(':');
-  const vpcConfig = existingFunction[0].values.vpc_config;
-
-  // TODO: We'll make these configurable, once we pass the configuration
-  //   via environment variables to the deploy-trigger lambda: lambdaTimeout,
-  //   deploymentName, defaultRuntime, tags, lambdaRolePermissionsBoundary
-
-  try {
-    const config: CreateDeploymentConfiguration = {
-      accountId: topicArn[4],
-      defaultFunctionMemory: 1024,
-      defaultRuntime: 'nodejs14.x',
-      deploymentName: 'tf-next',
-      lambdaAttachToVpc: false,
-      lambdaEnvironmentVariables: existingFunction[0].values.environment[0]?.variables || {},
-      lambdaLoggingPolicyArn: lambdaLoggingPolicy[0].values.arn,
-      lambdaTimeout: 10,
-      proxyConfigBucket: proxyConfigStore[0].values.bucket,
-      proxyConfigTable: proxyConfigTable[0].values.name,
-      region: topicArn[3],
-      staticDeployBucket: staticDeploy[0].values.bucket,
-      vpcSecurityGroupIds: [],
-      vpcSubnetIds: [],
-    };
-
-    if (vpcConfig.length > 0) {
-      config.lambdaAttachToVpc = true;
-      config.vpcSecurityGroupIds = vpcConfig[0].security_group_ids;
-      config.vpcSubnetIds = vpcConfig[0].subnet_ids;
-    }
-
-    return config
-  } catch(err) {
-    throw new Error(`Could not read configuration successfully: ${inspect(err, undefined, 10)}`);
-  }
-}
-
-async function wait(ms: number): Promise<void> {
-  return new Promise((resolve, _) => {
-    setTimeout(() => resolve(), ms);
-  });
-}
-
-async function createIAM(
-  deploymentId: string,
-  lambdaConfigurations: LambdaConfigurations,
-  config: CreateDeploymentConfiguration,
-): Promise<RoleArns> {
-  const roleArns: RoleArns = {};
-
-  for (const key in lambdaConfigurations) {
-    const functionName = `${key}-${deploymentId}`;
-
-    const role = await iam.createRole({
-      AssumeRolePolicyDocument: assumeRolePolicy,
-      RoleName: functionName,
-      Description: 'Managed by Terraform Next.js',
-      Tags: [],
-    }).promise();
-    roleArns[key] = role.Role.Arn;
-
-    const logGroupName = `/aws/lambda/${functionName}`;
-
-    await cloudWatch.createLogGroup({
-      logGroupName,
-    }).promise();
-
-    await cloudWatch.putRetentionPolicy({
-      logGroupName,
-      retentionInDays: 14,
-    }).promise();
-
-    await iam.attachRolePolicy({
-      PolicyArn: config.lambdaLoggingPolicyArn,
-      RoleName: functionName,
-    }).promise();
-
-    if (config.lambdaAttachToVpc) {
-      await iam.attachRolePolicy({
-        PolicyArn: 'arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole',
-        RoleName: functionName,
-      }).promise();
-    }
-  }
-
-  // We wait for 6s, because trying to use the roles too quickly after deleting them
-  // can lead to an `InvalidParameterValueException` with the message
-  // `The role defined for the function cannot be assumed by Lambda.`.
-  await wait(6000);
-
-  return roleArns;
-}
-
-async function createLambdas(
-  deploymentId: string,
-  configDir: string,
-  lambdaConfigurations: LambdaConfigurations,
-  roleArns: RoleArns,
-  config: CreateDeploymentConfiguration,
-): Promise<LambdaArns> {
-  const arns: LambdaArns = {};
-
-  for (const key in lambdaConfigurations) {
-    const fileContent = await fs.readFile(path.join(configDir, lambdaConfigurations[key]!.filename));
-    const params: Lambda.Types.CreateFunctionRequest = {
-      Code: {
-        ZipFile: fileContent,
-      },
-      FunctionName: `${key}-${deploymentId}`,
-      Role: roleArns[key]!, // We know this exists because we created it in `createIAM`
-      Description: 'Managed by Terraform-next.js',
-      Environment: {
-        Variables: config.lambdaEnvironmentVariables,
-      },
-      Handler: lambdaConfigurations[key]?.handler || '',
-      MemorySize: lambdaConfigurations[key]?.memory || config.defaultFunctionMemory,
-      PackageType: 'Zip', // Default in TF
-      Publish: false, // Default in TF
-      Runtime: lambdaConfigurations[key]?.runtime || config.defaultRuntime,
-      Tags: {},
-      Timeout: config.lambdaTimeout,
-      VpcConfig: {},
-    };
-    if (config.lambdaAttachToVpc) {
-      params.VpcConfig!.SecurityGroupIds = config.vpcSecurityGroupIds;
-      params.VpcConfig!.SubnetIds = config.vpcSubnetIds;
-    }
-    const createdLambda = await lambda.createFunction(params).promise();
-
-    if (createdLambda.FunctionArn) {
-      arns[key] = createdLambda.FunctionArn;
-    } else {
-      throw new Error(`Created lambda does not have arn: ${inspect(createdLambda)}`);
-    }
-  }
-
-  return arns;
-}
-
-async function createAPIGateway(
-  deploymentId: string,
-  lambdaConfigurations: LambdaConfigurations,
-  lambdaArns: LambdaArns,
-  config: CreateDeploymentConfiguration,
-): Promise<{ apiId: string, executeArn: string }> {
-  const api = await apiGatewayV2.createApi({
-    Name: `${config.deploymentName} - ${deploymentId}`,
-    ProtocolType: 'HTTP',
-    ApiKeySelectionExpression: '$request.header.x-api-key',
-    Description: 'Managed by Terraform-next.js',
-    RouteSelectionExpression: '$request.method $request.path',
-    Tags: {},
-  }).promise();
-
-  if (api.ApiId === undefined) {
-    throw new Error(`Created API gateway does not have an id: ${inspect(api)}`);
-  }
-
-  const stage = await apiGatewayV2.createStage({
-    ApiId: api.ApiId,
-    StageName: '$default',
-    AutoDeploy: true,
-    Description: 'Managed by Terraform-next.js',
-  }).promise();
-
-  for (const key in lambdaConfigurations) {
-    const integration = await apiGatewayV2.createIntegration({
-      ApiId: api.ApiId,
-      IntegrationType: 'AWS_PROXY',
-      Description: 'Managed by Terraform-next.js',
-      IntegrationMethod: 'POST',
-      IntegrationUri: lambdaArns[key],
-      PayloadFormatVersion: '2.0',
-      TimeoutInMillis: config.lambdaTimeout * 1000,
-    }).promise();
-
-    await apiGatewayV2.createRoute({
-      ApiId: api.ApiId,
-      RouteKey: `ANY ${lambdaConfigurations[key]?.route}/{proxy+}`,
-      AuthorizationType: 'NONE',
-      Target: `integrations/${integration.IntegrationId}`,
-    }).promise();
-  }
-
-  // The ARN prefix to be used in an aws_lambda_permission's source_arn attribute or in an aws_iam_policy to authorize access to the @connections API.
-  return {
-    apiId: api.ApiId,
-    executeArn: `arn:aws:execute-api:${config.region}:${config.accountId}:${api.ApiId}`,
-  };
-}
-
-async function createLambdaPermissions(
-  deploymentId: string,
-  lambdaConfigurations: LambdaConfigurations,
-  executeArn: string,
-) {
-  for (const key in lambdaConfigurations) {
-    await lambda.addPermission({
-      Action: 'lambda:InvokeFunction',
-      FunctionName: `${key}-${deploymentId}`,
-      Principal: 'apigateway.amazonaws.com',
-      StatementId: 'AllowInvokeFromApiGateway',
-      SourceArn: `${executeArn}/*/*/*`,
-    }).promise();
-  }
-}
-
-async function uploadProxyConfig(
-  deploymentId: string,
-  config: ProxyConfig,
-  bucket: string,
-  table: string,
-) {
-  const configString = JSON.stringify(config);
-
-  await s3.putObject({
-    Body: configString,
-    Bucket: bucket,
-    ContentType: 'application/json',
-    Key: `${deploymentId}/proxy-config.json`,
-  }).promise();
-
-  await dynamoDB.putItem({
-    TableName: table,
-    Item: {
-      alias: {
-        S: deploymentId,
-      },
-      proxyConfig: {
-        S: configString,
-      },
-    },
-  }).promise();
 }
 
 function log(deploymentId: string, message: string, logLevel: LogLevel) {
@@ -334,89 +26,28 @@ async function createDeploymentCommand({
   deploymentId,
   logLevel,
   cwd,
+  deploymentArchive,
   staticFilesArchive,
-  terraformState,
+  deployBucket,
   target = 'AWS',
 }: CreateDeploymentProps) {
-  const config = await readConfig(terraformState);
+  // Upload deployment archive
+  await s3.putObject({
+    Body: (await fs.readFile(path.join(cwd, '.next-tf', deploymentArchive))),
+    Bucket: deployBucket,
+    Key: deploymentArchive,
+  }).promise();
 
-  const configDir = path.join(cwd, '.next-tf');
-  const configFile = require(path.join(configDir, 'config.json'));
-  const lambdaConfigurations = configFile.lambdas;
-
-  // Create IAM & CW resources
-  const roleArns = await createIAM(
-    deploymentId,
-    lambdaConfigurations,
-    config,
-  );
-
-  log(deploymentId, 'created log groups and roles.', logLevel);
-
-  // Create lambdas
-  const lambdaArns = await createLambdas(
-    deploymentId,
-    configDir,
-    lambdaConfigurations,
-    roleArns,
-    config,
-  );
-
-  log(deploymentId, 'created lambda functions.', logLevel);
-
-  // Create API Gateway
-  const { apiId, executeArn } = await createAPIGateway(
-    deploymentId,
-    lambdaConfigurations,
-    lambdaArns,
-    config,
-  );
-
-  log(deploymentId, 'created API gateway.', logLevel);
-
-  // Create lambda permissions
-  await createLambdaPermissions(
-    deploymentId,
-    lambdaConfigurations,
-    executeArn,
-  );
-
-  log(deploymentId, 'created lambda permissions.', logLevel);
-
-  // Modify proxy config to include API Gateway id and match expected format
-  const lambdaRoutes = [];
-  for (const key in lambdaConfigurations) {
-    lambdaRoutes.push(lambdaConfigurations[key].route || '/');
-  }
-
-  const modifiedProxyConfig: ProxyConfig = {
-    apiId,
-    routes: configFile.routes,
-    prerenders: configFile.prerenders,
-    staticRoutes: configFile.staticRoutes,
-    lambdaRoutes,
-  };
-
-  // Upload proxy config to bucket
-  await uploadProxyConfig(
-    deploymentId,
-    modifiedProxyConfig,
-    config.proxyConfigBucket,
-    config.proxyConfigTable,
-  );
-
-  log(deploymentId, 'created proxy config.', logLevel);
+  log(deploymentId, 'uploaded deployment archive.', logLevel);
 
   // Upload static assets
   await s3.putObject({
     Body: (await fs.readFile(path.join(cwd, '.next-tf', staticFilesArchive))),
-    Bucket: config.staticDeployBucket,
+    Bucket: deployBucket,
     Key: staticFilesArchive,
   }).promise();
 
   log(deploymentId, 'uploaded static assets.', logLevel);
-
-  // Image optimizer stuff
 }
 
 export default createDeploymentCommand;

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -147,6 +147,7 @@ describe('Test proxy config', () => {
               environment: {
                 TARGET_BUCKET: staticFilesBucket.bucketName,
                 EXPIRE_AFTER_DAYS: '0',
+                STATIC_FILES_ARCHIVE: 'static-website-files.zip',
                 // No CF invalidation is created
                 __DEBUG__SKIP_INVALIDATIONS: 'true',
                 __DEBUG__USE_LOCAL_BUCKET: JSON.stringify({
@@ -324,6 +325,7 @@ describe('Test proxy config', () => {
               // Request should be served by static file system (S3)
               // Check static routes
               const { uri } = Request;
+
               if (config.staticRoutes.find((route) => route === uri)) {
                 const filePath = uri.replace(/^\//, '');
 


### PR DESCRIPTION
This is the fifth PR in a series to introduce the handling of multiple parallel deployments.

What this PR does:

* Preparation for removing code duplication by letting the deploy trigger handle the infra creation

Things left to do:

* Allow for things like tags, role boundaries, etc. to be passed on to the create-deployment command
* Remove code duplication (TF/TS)
* Documentation/an example of how to setup wildcard subdomains for this
* New architecture picture
