### PR TITLE
chore: add cloudfront aliases for custom domain

### DIFF
--- a/examples/with-custom-domain/main.tf
+++ b/examples/with-custom-domain/main.tf
@@ -83,8 +83,8 @@ module "cloudfront_cert" {
   source  = "terraform-aws-modules/acm/aws"
   version = "~> 3.0"
 
-  domain_name = var.custom_domain
-  zone_id     = data.aws_route53_zone.custom_domain_zone.zone_id
+  domain_name               = var.custom_domain
+  zone_id                   = data.aws_route53_zone.custom_domain_zone.zone_id
   subject_alternative_names = slice(local.aliases, 1, length(local.aliases))
 
   tags = {

--- a/examples/with-custom-domain/main.tf
+++ b/examples/with-custom-domain/main.tf
@@ -38,6 +38,15 @@ variable "custom_domain_zone_name" {
   default     = "example.com."
 }
 
+###########
+# Locals
+###########
+
+locals {
+  aliases = [var.custom_domain]
+  # If you need a wildcard domain(ex: *.example.com), you can add it like this:
+  # aliases = [var.custom_domain, "*.${var.custom_domain}"]
+}
 
 #######################
 # Route53 Domain record
@@ -50,13 +59,15 @@ data "aws_route53_zone" "custom_domain_zone" {
 
 # Create a new record in Route 53 for the domain
 resource "aws_route53_record" "cloudfront_alias_domain" {
+  for_each = toset(local.aliases)
+
   zone_id = data.aws_route53_zone.custom_domain_zone.zone_id
-  name    = var.custom_domain
+  name    = each.key
   type    = "A"
 
   alias {
-    name                   = aws_cloudfront_distribution.distribution.domain_name
-    zone_id                = aws_cloudfront_distribution.distribution.hosted_zone_id
+    name                   = module.tf_next.cloudfront_domain_name
+    zone_id                = module.tf_next.cloudfront_hosted_zone_id
     evaluate_target_health = false
   }
 }
@@ -74,6 +85,7 @@ module "cloudfront_cert" {
 
   domain_name = var.custom_domain
   zone_id     = data.aws_route53_zone.custom_domain_zone.zone_id
+  subject_alternative_names = slice(local.aliases, 1, length(local.aliases))
 
   tags = {
     Name = "CloudFront ${var.custom_domain}"
@@ -92,10 +104,8 @@ module "cloudfront_cert" {
 module "tf_next" {
   source = "dealmore/next-js/aws"
 
-  # Prevent creation of the main CloudFront distribution
-  cloudfront_create_distribution = false
-  cloudfront_external_id         = aws_cloudfront_distribution.distribution.id
-  cloudfront_external_arn        = aws_cloudfront_distribution.distribution.arn
+  cloudfront_aliases             = local.aliases
+  cloudfront_acm_certificate_arn = module.cloudfront_cert.acm_certificate_arn
 
   deployment_name = "terraform-next-js-example-custom-domain"
   providers = {
@@ -105,154 +115,6 @@ module "tf_next" {
   # Uncomment when using in the cloned monorepo for tf-next development
   # source = "../.."
   # debug_use_local_packages = true
-}
-
-#########################
-# CloudFront distribution
-#########################
-
-# You can fully customize all the settings of the CloudFront distribution
-# as described in the AWS Provider documentation:
-# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution
-resource "aws_cloudfront_distribution" "distribution" {
-  enabled             = true
-  is_ipv6_enabled     = true
-  comment             = "terraform-next-js-example-custom-domain"
-  aliases             = [var.custom_domain]
-  default_root_object = module.tf_next.cloudfront_default_root_object
-
-  # Default cache behavior
-  ########################
-  # Inserts the preconfigured default cache behavior from the tf-next module
-  # No manual edits should be neccessary here
-  dynamic "default_cache_behavior" {
-    for_each = module.tf_next.cloudfront_default_cache_behavior
-
-    content {
-      allowed_methods  = default_cache_behavior.value["allowed_methods"]
-      cached_methods   = default_cache_behavior.value["cached_methods"]
-      target_origin_id = default_cache_behavior.value["target_origin_id"]
-
-      viewer_protocol_policy = default_cache_behavior.value["viewer_protocol_policy"]
-      compress               = default_cache_behavior.value["compress"]
-
-      origin_request_policy_id = default_cache_behavior.value["origin_request_policy_id"]
-      cache_policy_id          = default_cache_behavior.value["cache_policy_id"]
-
-      dynamic "lambda_function_association" {
-        for_each = [default_cache_behavior.value["lambda_function_association"]]
-
-        content {
-          event_type   = lambda_function_association.value["event_type"]
-          lambda_arn   = lambda_function_association.value["lambda_arn"]
-          include_body = lambda_function_association.value["include_body"]
-        }
-      }
-    }
-  }
-
-  # Ordered cache behaviors
-  #########################
-  # Inserts the preconfigured ordered cache behaviors from the tf-next module
-  # No manual edits should be neccessary here
-  dynamic "ordered_cache_behavior" {
-    for_each = module.tf_next.cloudfront_ordered_cache_behaviors
-
-    content {
-      path_pattern     = ordered_cache_behavior.value["path_pattern"]
-      allowed_methods  = ordered_cache_behavior.value["allowed_methods"]
-      cached_methods   = ordered_cache_behavior.value["cached_methods"]
-      target_origin_id = ordered_cache_behavior.value["target_origin_id"]
-
-      compress               = ordered_cache_behavior.value["compress"]
-      viewer_protocol_policy = ordered_cache_behavior.value["viewer_protocol_policy"]
-
-      origin_request_policy_id = ordered_cache_behavior.value["origin_request_policy_id"]
-      cache_policy_id          = ordered_cache_behavior.value["cache_policy_id"]
-    }
-  }
-
-  # Origins
-  #########
-  # Adds the preconfigured origins from the tf-next module
-  # No manual edits should be neccessary here
-  dynamic "origin" {
-    for_each = module.tf_next.cloudfront_origins
-
-    content {
-      domain_name = origin.value["domain_name"]
-      origin_id   = origin.value["origin_id"]
-
-      # Origin Shield
-      dynamic "origin_shield" {
-        for_each = lookup(origin.value, "origin_shield", null) != null ? [true] : []
-
-        content {
-          enabled              = lookup(origin.value["origin_shield"], "enabled", false)
-          origin_shield_region = lookup(origin.value["origin_shield"], "origin_shield_region", null)
-        }
-      }
-
-      # S3 origin
-      dynamic "s3_origin_config" {
-        for_each = lookup(origin.value, "s3_origin_config", null) != null ? [true] : []
-        content {
-          origin_access_identity = lookup(origin.value["s3_origin_config"], "origin_access_identity", null)
-        }
-      }
-
-      # Custom origin
-      dynamic "custom_origin_config" {
-        for_each = lookup(origin.value, "custom_origin_config", null) != null ? [true] : []
-
-        content {
-          http_port                = lookup(origin.value["custom_origin_config"], "http_port", null)
-          https_port               = lookup(origin.value["custom_origin_config"], "https_port", null)
-          origin_protocol_policy   = lookup(origin.value["custom_origin_config"], "origin_protocol_policy", null)
-          origin_ssl_protocols     = lookup(origin.value["custom_origin_config"], "origin_ssl_protocols", null)
-          origin_keepalive_timeout = lookup(origin.value["custom_origin_config"], "origin_keepalive_timeout", null)
-          origin_read_timeout      = lookup(origin.value["custom_origin_config"], "origin_read_timeout", null)
-        }
-      }
-
-      dynamic "custom_header" {
-        for_each = lookup(origin.value, "custom_header", null) != null ? origin.value["custom_header"] : []
-
-        content {
-          name  = custom_header.value["name"]
-          value = custom_header.value["value"]
-        }
-      }
-    }
-  }
-
-  # Custom Error response (S3 failover)
-  #####################################
-  # Adds the preconfigured custom error response from the tf-next module
-  # No manual edits should be neccessary here
-  dynamic "custom_error_response" {
-    for_each = module.tf_next.cloudfront_custom_error_response
-
-    content {
-      error_caching_min_ttl = custom_error_response.value["error_caching_min_ttl"]
-      error_code            = custom_error_response.value["error_code"]
-      response_code         = custom_error_response.value["response_code"]
-      response_page_path    = custom_error_response.value["response_page_path"]
-    }
-  }
-
-  viewer_certificate {
-    cloudfront_default_certificate = false
-    acm_certificate_arn            = module.cloudfront_cert.acm_certificate_arn
-    ssl_support_method             = "sni-only"
-    minimum_protocol_version       = "TLSv1"
-  }
-
-  restrictions {
-    geo_restriction {
-      restriction_type = "none"
-    }
-  }
 }
 
 #########

--- a/main.tf
+++ b/main.tf
@@ -427,7 +427,11 @@ module "cloudfront_main" {
 
   source = "./modules/cloudfront-main"
 
-  cloudfront_price_class             = var.cloudfront_price_class
+  cloudfront_price_class              = var.cloudfront_price_class
+  cloudfront_aliases                  = var.cloudfront_aliases
+  cloudfront_acm_certificate_arn      = var.cloudfront_acm_certificate_arn
+  cloudfront_minimum_protocol_version = var.cloudfront_minimum_protocol_version
+
   cloudfront_default_root_object     = local.cloudfront_default_root_object
   cloudfront_origins                 = local.cloudfront_origins
   cloudfront_default_behavior        = local.cloudfront_default_behavior

--- a/modules/cloudfront-main/main.tf
+++ b/modules/cloudfront-main/main.tf
@@ -3,6 +3,7 @@ resource "aws_cloudfront_distribution" "distribution" {
   is_ipv6_enabled     = true
   comment             = "${var.deployment_name} - Main"
   price_class         = var.cloudfront_price_class
+  aliases             = var.cloudfront_aliases
   default_root_object = var.cloudfront_default_root_object
 
   # Add CloudFront origins
@@ -115,7 +116,10 @@ resource "aws_cloudfront_distribution" "distribution" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
+    cloudfront_default_certificate = var.cloudfront_acm_certificate_arn == null
+    acm_certificate_arn            = var.cloudfront_acm_certificate_arn
+    minimum_protocol_version       = var.cloudfront_minimum_protocol_version
+    ssl_support_method             = var.cloudfront_acm_certificate_arn != null ? "sni-only" : null
   }
 
   restrictions {

--- a/modules/cloudfront-main/variables.tf
+++ b/modules/cloudfront-main/variables.tf
@@ -6,6 +6,21 @@ variable "cloudfront_price_class" {
   type = string
 }
 
+variable "cloudfront_aliases" {
+  type        = list(string)
+  default     = []
+}
+
+variable "cloudfront_acm_certificate_arn" {
+  type    = string
+  default = null
+}
+
+variable "cloudfront_minimum_protocol_version" {
+  type        = string
+  default     = "TLSv1"
+}
+
 variable "cloudfront_default_root_object" {
   type = string
 }

--- a/modules/cloudfront-main/variables.tf
+++ b/modules/cloudfront-main/variables.tf
@@ -7,8 +7,8 @@ variable "cloudfront_price_class" {
 }
 
 variable "cloudfront_aliases" {
-  type        = list(string)
-  default     = []
+  type    = list(string)
+  default = []
 }
 
 variable "cloudfront_acm_certificate_arn" {
@@ -17,8 +17,8 @@ variable "cloudfront_acm_certificate_arn" {
 }
 
 variable "cloudfront_minimum_protocol_version" {
-  type        = string
-  default     = "TLSv1"
+  type    = string
+  default = "TLSv1"
 }
 
 variable "cloudfront_default_root_object" {

--- a/variables.tf
+++ b/variables.tf
@@ -104,6 +104,24 @@ variable "cloudfront_price_class" {
   default     = "PriceClass_100"
 }
 
+variable "cloudfront_aliases" {
+  description = "Aliases for custom_domain"
+  type        = list(string)
+  default     = []
+}
+
+variable "cloudfront_acm_certificate_arn" {
+  description = "ACM certificate arn for custom_domain"
+  type    = string
+  default = null
+}
+
+variable "cloudfront_minimum_protocol_version" {
+  description = "The minimum version of the SSL protocol that you want CloudFront to use for HTTPS connections. One of SSLv3, TLSv1, TLSv1_2016, TLSv1.1_2016, TLSv1.2_2018 or TLSv1.2_2019."
+  type        = string
+  default     = "TLSv1"
+}
+
 variable "cloudfront_origin_headers" {
   description = "Header keys that should be sent to the S3 or Lambda origins. Should not contain any header that is defined via cloudfront_cache_key_headers."
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -112,8 +112,8 @@ variable "cloudfront_aliases" {
 
 variable "cloudfront_acm_certificate_arn" {
   description = "ACM certificate arn for custom_domain"
-  type    = string
-  default = null
+  type        = string
+  default     = null
 }
 
 variable "cloudfront_minimum_protocol_version" {


### PR DESCRIPTION
- Since the main cloudfront is constantly updated, users who use custom domains have the problem of having to keep following these updates on their own cloudfront.
- This PR enables the use of a custom domain without creating a separate cloudfront.