### PR TITLE
Bump milliHQ/download/npm from 1.1.0 to 2.0.0

### DIFF
--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -1,6 +1,6 @@
 module "proxy_package" {
-  source  = "dealmore/download/npm"
-  version = "1.1.0"
+  source  = "milliHQ/download/npm"
+  version = "2.0.0"
 
   module_name    = "@dealmore/terraform-next-proxy"
   module_version = var.proxy_module_version

--- a/modules/statics-deploy/main.tf
+++ b/modules/statics-deploy/main.tf
@@ -158,8 +158,8 @@ data "aws_iam_policy_document" "access_sqs_queue" {
 }
 
 module "lambda_content" {
-  source  = "dealmore/download/npm"
-  version = "1.1.0"
+  source  = "milliHQ/download/npm"
+  version = "2.0.0"
 
   module_name    = "@dealmore/terraform-next-deploy-trigger"
   module_version = var.deploy_trigger_module_version


### PR DESCRIPTION
When upgrading from a previous version of the module, Terraform may fail with an error that the final plan has changed during apply (Inconsistent final plan).
That was caused by the `milliHQ/download/npm module` that downloaded the source of the Lambda in parallel to running the apply.
In 2.0.0 this behavior was fixed, so that Terraform waits until the download is finished before progreeding.