### PR TITLE
docs: update with-custom-domain example's README

### DIFF
--- a/examples/with-custom-domain/README.md
+++ b/examples/with-custom-domain/README.md
@@ -1,7 +1,6 @@
 # Terraform Next.js custom domain example
 
 This example shows how to use a custom domain with the [Next.js Terraform module for AWS](https://registry.terraform.io/modules/milliHQ/next-js/aws).
-The code is based on the [with existing CloudFront distribution example](https://github.com/milliHQ/terraform-aws-next-js/tree/main/examples/with-existing-cloudfront).
 
 ## Features
 


### PR DESCRIPTION
- It is a just README change in with-custom-domain example.
- This example is no longer based on the with-existing-cloudfront example.
- This is the part that was omitted from #192.