### PR TITLE
Use configuration aliases to pass global provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A zero-config Terraform module for self-hosting Next.js sites serverless on AWS 
 Some features are still under development, here is a list of features that are currently supported and what we plan to bring with the next releases:
 
 - ✅ &nbsp;[Next.js](https://nextjs.org/) 11, 10 & 9 support
-- ✅ &nbsp;[Terraform](https://www.terraform.io/) `v0.13+`
+- ✅ &nbsp;[Terraform](https://www.terraform.io/) `v0.15+`
 - ✅ &nbsp;Static, SSG, Lambda and API pages (with [dynamic routes](https://nextjs.org/docs/routing/dynamic-routes))
 - ✅ &nbsp;Automatic expiration of old static assets
 - ✅ &nbsp;[Rewrites](https://nextjs.org/docs/api-reference/next.config.js/rewrites) & [Redirects](https://nextjs.org/docs/api-reference/next.config.js/redirects)

--- a/modules/proxy/provider.tf
+++ b/modules/proxy/provider.tf
@@ -1,4 +1,0 @@
-# Proxy AWS provider for Lambda@Edge
-provider "aws" {
-  alias = "global_region"
-}

--- a/modules/proxy/versions.tf
+++ b/modules/proxy/versions.tf
@@ -1,11 +1,13 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.15"
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 3.0"
+      source                = "hashicorp/aws"
+      version               = ">= 3.0"
+      configuration_aliases = [aws.global_region]
     }
+
     random = {
       source  = "hashicorp/random"
       version = ">= 2.3.0"

--- a/provider.tf
+++ b/provider.tf
@@ -1,4 +1,0 @@
-# Proxy AWS provider for Lambda@Edge
-provider "aws" {
-  alias = "global_region"
-}

--- a/versions.tf
+++ b/versions.tf
@@ -1,11 +1,13 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.15"
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 3.43.0"
+      source                = "hashicorp/aws"
+      version               = ">= 3.43.0"
+      configuration_aliases = [aws.global_region]
     }
+
     random = {
       source  = "hashicorp/random"
       version = ">= 2.3.0"


### PR DESCRIPTION
- Increases minimum required Terraform version to `v0.15`
- Proxying global AWS provider to internal proxy module is now done via `configuration_aliases `

Fixes #155.