### PR TITLE
Remove random IDs from resources

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -23,7 +23,7 @@ provider "aws" {
 module "tf_next" {
   source = "milliHQ/next-js/aws"
 
-  deployment_name = "terraform-next-js-example-complete"
+  deployment_name = "tf-next-example-complete"
 
   providers = {
     aws.global_region = aws.global_region

--- a/examples/next-image/main.tf
+++ b/examples/next-image/main.tf
@@ -23,7 +23,7 @@ provider "aws" {
 module "tf_next" {
   source = "milliHQ/next-js/aws"
 
-  deployment_name = "terraform-next-js-example-image"
+  deployment_name = "tf-next-example-image"
 
   providers = {
     aws.global_region = aws.global_region

--- a/examples/static/main.tf
+++ b/examples/static/main.tf
@@ -23,7 +23,7 @@ provider "aws" {
 module "tf_next" {
   source = "milliHQ/next-js/aws"
 
-  deployment_name = "terraform-next-js-example-static"
+  deployment_name = "tf-next-example-static"
 
   providers = {
     aws.global_region = aws.global_region

--- a/examples/with-custom-domain/main.tf
+++ b/examples/with-custom-domain/main.tf
@@ -107,7 +107,7 @@ module "tf_next" {
   cloudfront_aliases             = local.aliases
   cloudfront_acm_certificate_arn = module.cloudfront_cert.acm_certificate_arn
 
-  deployment_name = "terraform-next-js-example-custom-domain"
+  deployment_name = "tf-next-example-custom-domain"
   providers = {
     aws.global_region = aws.global_region
   }

--- a/examples/with-existing-cloudfront/main.tf
+++ b/examples/with-existing-cloudfront/main.tf
@@ -32,7 +32,7 @@ module "tf_next" {
   cloudfront_external_id         = aws_cloudfront_distribution.distribution.id
   cloudfront_external_arn        = aws_cloudfront_distribution.distribution.arn
 
-  deployment_name = "terraform-next-js-existing-cloudfront"
+  deployment_name = "tf-next-existing-cloudfront"
 
   providers = {
     aws.global_region = aws.global_region

--- a/iam.tf
+++ b/iam.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "assume_role" {
 resource "aws_iam_role" "lambda" {
   for_each = local.lambdas
 
-  name        = random_id.function_name[each.key].hex
+  name        = "${var.deployment_name}_${each.key}"
   description = "Managed by Terraform Next.js"
 
   permissions_boundary = var.lambda_role_permissions_boundary
@@ -34,7 +34,7 @@ resource "aws_iam_role" "lambda" {
 resource "aws_cloudwatch_log_group" "this" {
   for_each = local.lambdas
 
-  name              = "/aws/lambda/${random_id.function_name[each.key].hex}"
+  name              = "/aws/lambda/${var.deployment_name}_${each.key}"
   retention_in_days = 14
 
   tags = var.tags
@@ -59,6 +59,8 @@ resource "aws_iam_policy" "lambda_logging" {
   description = "Managed by Terraform Next.js"
 
   policy = data.aws_iam_policy_document.lambda_logging.json
+
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_logs" {
@@ -85,6 +87,8 @@ resource "aws_iam_policy" "additional_json" {
 
   description = "Managed by Terraform Next.js"
   policy      = var.lambda_policy_json
+
+  tags = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "additional_json" {

--- a/main.tf
+++ b/main.tf
@@ -24,14 +24,6 @@ locals {
   })
 }
 
-# Generates for each function a unique function name
-resource "random_id" "function_name" {
-  for_each = local.lambdas
-
-  prefix      = "${each.key}-"
-  byte_length = 4
-}
-
 #########
 # Lambdas
 #########
@@ -61,8 +53,8 @@ module "statics_deploy" {
 resource "aws_lambda_function" "this" {
   for_each = local.lambdas
 
-  function_name = random_id.function_name[each.key].hex
-  description   = "Managed by Terraform-next.js"
+  function_name = "${var.deployment_name}_${each.key}"
+  description   = "Managed by Terraform Next.js"
   role          = aws_iam_role.lambda[each.key].arn
   handler       = lookup(each.value, "handler", "")
   runtime       = lookup(each.value, "runtime", var.lambda_runtime)
@@ -98,7 +90,7 @@ resource "aws_lambda_permission" "current_version_triggers" {
 
   statement_id  = "AllowInvokeFromApiGateway"
   action        = "lambda:InvokeFunction"
-  function_name = random_id.function_name[each.key].hex
+  function_name = "${var.deployment_name}_${each.key}"
   principal     = "apigateway.amazonaws.com"
 
   source_arn = "${module.api_gateway.apigatewayv2_api_execution_arn}/*/*/*"
@@ -129,7 +121,7 @@ module "api_gateway" {
   version = "1.1.0"
 
   name          = var.deployment_name
-  description   = "Managed by Terraform-next.js"
+  description   = "Managed by Terraform Next.js"
   protocol_type = "HTTP"
 
   create_api_domain_name = false
@@ -176,7 +168,7 @@ module "next_image" {
   lambda_policy_json               = data.aws_iam_policy_document.access_static_deployment.json
   lambda_role_permissions_boundary = var.lambda_role_permissions_boundary
 
-  deployment_name = var.deployment_name
+  deployment_name = "${var.deployment_name}_tfn-image"
   tags            = var.tags
 }
 
@@ -198,11 +190,6 @@ module "proxy_config" {
 #####################
 # Proxy (Lambda@Edge)
 #####################
-
-resource "random_id" "policy_name" {
-  prefix      = "${var.deployment_name}-"
-  byte_length = 4
-}
 
 module "proxy" {
   source = "./modules/proxy"
@@ -255,7 +242,7 @@ locals {
 }
 
 resource "aws_cloudfront_cache_policy" "this" {
-  name    = "${random_id.policy_name.hex}-cache"
+  name    = "${var.deployment_name}_tfn-cache"
   comment = "Managed by Terraform Next.js"
 
   # Default values (Should be provided by origin)

--- a/modules/cloudfront-proxy-config/main.tf
+++ b/modules/cloudfront-proxy-config/main.tf
@@ -9,7 +9,7 @@ locals {
 ########
 
 resource "aws_s3_bucket" "proxy_config_store" {
-  bucket_prefix = "next-tf-proxy-config"
+  bucket_prefix = "${var.deployment_name}-tfn-config"
   acl           = "private"
   force_destroy = true
   tags          = var.tags

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -13,18 +13,13 @@ module "proxy_package" {
 # Lambda@Edge
 #############
 
-resource "random_id" "function_name" {
-  prefix      = "next-tf-proxy-"
-  byte_length = 4
-}
-
 module "edge_proxy" {
   source  = "terraform-aws-modules/lambda/aws"
   version = "2.4.0"
 
   lambda_at_edge = true
 
-  function_name             = random_id.function_name.hex
+  function_name             = "${var.deployment_name}_tfn-proxy"
   description               = "Managed by Terraform Next.js"
   handler                   = "handler.handler"
   runtime                   = var.lambda_default_runtime

--- a/modules/proxy/versions.tf
+++ b/modules/proxy/versions.tf
@@ -7,10 +7,5 @@ terraform {
       version               = ">= 3.0"
       configuration_aliases = [aws.global_region]
     }
-
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 2.3.0"
-    }
   }
 }

--- a/modules/statics-deploy/main.tf
+++ b/modules/statics-deploy/main.tf
@@ -8,7 +8,7 @@ locals {
 ########################
 
 resource "aws_s3_bucket" "static_upload" {
-  bucket_prefix = "next-tf-deploy-source"
+  bucket_prefix = "${var.deployment_name}-tfn-deploy"
   acl           = "private"
   force_destroy = true
   tags          = var.tags
@@ -33,7 +33,7 @@ resource "aws_s3_bucket_notification" "on_create" {
 #########################
 
 resource "aws_s3_bucket" "static_deploy" {
-  bucket_prefix = "next-tf-static-deploy"
+  bucket_prefix = "${var.deployment_name}-tfn-static"
   acl           = "private"
   force_destroy = true
   tags          = var.tags
@@ -168,17 +168,12 @@ module "lambda_content" {
   local_cwd      = var.tf_next_module_root
 }
 
-resource "random_id" "function_name" {
-  prefix      = "next-tf-deploy-"
-  byte_length = 4
-}
-
 module "deploy_trigger" {
   source  = "terraform-aws-modules/lambda/aws"
   version = "2.4.0"
 
-  function_name             = random_id.function_name.hex
-  description               = "Managed by Terraform-next.js"
+  function_name             = "${var.deployment_name}_tfn-deploy"
+  description               = "Managed by Terraform Next.js"
   handler                   = "handler.handler"
   runtime                   = "nodejs14.x"
   memory_size               = 1024

--- a/modules/statics-deploy/versions.tf
+++ b/modules/statics-deploy/versions.tf
@@ -10,9 +10,5 @@ terraform {
       source  = "hashicorp/null"
       version = ">= 2.1.2"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 2.3.0"
-    }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -150,9 +150,14 @@ variable "cloudfront_external_arn" {
 # Labeling
 ##########
 variable "deployment_name" {
-  description = "Identifier for the deployment group (alphanumeric characters, underscores, hyphens, slashes, hash signs and dots are allowed)."
+  description = "Identifier for the deployment group (only lowercase alphanumeric characters and hyphens are allowed)."
   type        = string
   default     = "tf-next"
+
+  validation {
+    condition     = can(regex("[a-z0-9-]+", var.deployment_name))
+    error_message = "Only lowercase alphanumeric characters and hyphens allowed."
+  }
 }
 
 variable "tags" {

--- a/versions.tf
+++ b/versions.tf
@@ -7,10 +7,5 @@ terraform {
       version               = ">= 3.43.0"
       configuration_aliases = [aws.global_region]
     }
-
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 2.3.0"
-    }
   }
 }


### PR DESCRIPTION
This makes resource names more predictable.
It removes random generated strings from the resource names and instead uses the `deplotyment_name` variable if possible.

fixes #212.