### PR TITLE
Adds new input variable tags_s3_bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,7 @@ module "statics_deploy" {
 
   deployment_name = var.deployment_name
   tags            = var.tags
+  tags_s3_bucket  = var.tags_s3_bucket
 
   debug_use_local_packages = var.debug_use_local_packages
   tf_next_module_root      = path.module
@@ -185,6 +186,7 @@ module "proxy_config" {
 
   deployment_name = var.deployment_name
   tags            = var.tags
+  tags_s3_bucket  = var.tags_s3_bucket
 }
 
 #####################

--- a/modules/cloudfront-proxy-config/main.tf
+++ b/modules/cloudfront-proxy-config/main.tf
@@ -12,7 +12,7 @@ resource "aws_s3_bucket" "proxy_config_store" {
   bucket_prefix = "${var.deployment_name}-tfn-config"
   acl           = "private"
   force_destroy = true
-  tags          = var.tags
+  tags          = merge(var.tags, var.tags_s3_bucket)
 }
 
 data "aws_iam_policy_document" "cf_access" {

--- a/modules/cloudfront-proxy-config/variables.tf
+++ b/modules/cloudfront-proxy-config/variables.tf
@@ -36,3 +36,8 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "tags_s3_bucket" {
+  type    = map(string)
+  default = {}
+}

--- a/modules/statics-deploy/main.tf
+++ b/modules/statics-deploy/main.tf
@@ -11,12 +11,13 @@ resource "aws_s3_bucket" "static_upload" {
   bucket_prefix = "${var.deployment_name}-tfn-deploy"
   acl           = "private"
   force_destroy = true
-  tags          = var.tags
 
   # We are using versioning here to ensure that no file gets overridden at upload
   versioning {
     enabled = true
   }
+
+  tags = merge(var.tags, var.tags_s3_bucket)
 }
 
 resource "aws_s3_bucket_notification" "on_create" {
@@ -36,7 +37,6 @@ resource "aws_s3_bucket" "static_deploy" {
   bucket_prefix = "${var.deployment_name}-tfn-static"
   acl           = "private"
   force_destroy = true
-  tags          = var.tags
 
   lifecycle_rule {
     id      = "Expire static assets"
@@ -50,6 +50,8 @@ resource "aws_s3_bucket" "static_deploy" {
       days = var.expire_static_assets > 0 ? var.expire_static_assets : 0
     }
   }
+
+  tags = merge(var.tags, var.tags_s3_bucket)
 }
 
 # CloudFront permissions for the bucket

--- a/modules/statics-deploy/variables.tf
+++ b/modules/statics-deploy/variables.tf
@@ -56,6 +56,11 @@ variable "tags" {
   default = {}
 }
 
+variable "tags_s3_bucket" {
+  type    = map(string)
+  default = {}
+}
+
 #######
 # Debug
 #######

--- a/variables.tf
+++ b/variables.tf
@@ -166,6 +166,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "tags_s3_bucket" {
+  description = "Tag metadata to label AWS S3 buckets. Overrides tags with the same name in input variable tags."
+  type        = map(string)
+  default     = {}
+}
+
 ################
 # Debug Settings
 ################


### PR DESCRIPTION
Adds a new input variable `tags_s3_bucket`.
The tags that are set in `tags_s3_bucket` are only added to S3 buckets created by this module.

Closes #216.