### PR TITLE
Bump aws-sdk from 2.804.0 to 2.1001.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   },
   "resolutions": {
     "archiver": "^5.3.0",
-    "aws-sdk": "2.804.0"
+    "aws-sdk": "2.1001.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1387,10 +1387,10 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-aws-sdk@*, aws-sdk@2.804.0, aws-sdk@^2.804.0:
-  version "2.804.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.804.0.tgz#ff7e6f91b86b4878ec69e3de895c10eb8203fc4b"
-  integrity sha512-a02pZdjL06MunElAZPPEjpghOp/ZA+16f+t4imh1k9FCDpsNVQrT23HRq/PMvRADA5uZZRkYwX8r9o6oH/1RlA==
+aws-sdk@*, aws-sdk@2.1001.0, aws-sdk@^2.804.0:
+  version "2.1001.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1001.0.tgz#c4da256aa0058438ba611ae06fa850f4f7d63abc"
+  integrity sha512-DpmslPU8myCaaRUwMzB/SqAMtD2zQckxYwq3CguIv8BI+JHxDLeTdPCLfA5jffQ8k6dcvISOuiqdpwCZucU0BA==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
Use the same runtime as the Lambda runtime: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html