### PR TITLE
Set default ttl to 0 when no cache header present

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -249,7 +249,7 @@ resource "aws_cloudfront_cache_policy" "this" {
 
   # Default values (Should be provided by origin)
   min_ttl     = 0
-  default_ttl = 86400
+  default_ttl = 0
   max_ttl     = 31536000
 
   parameters_in_cache_key_and_forwarded_to_origin {


### PR DESCRIPTION
For routes where no `Cache-Control` header is present, the default TTL is not set to `0` (no cache).
This is especially useful for API-Routes in Next.js that do not add a `Cache-Control` header by default.

Fixes #236.