### PR TITLE
Using cloudfront_origin in terraform-aws-next-js-image-optimization module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -308,7 +308,7 @@ locals {
   _cloudfront_origins = {
     static_content = merge(local.cloudfront_origin_static_content, { create = true })
     next_image = merge(
-      var.create_image_optimization ? module.next_image[0].cloudfront_origin_image_optimizer : null, {
+      var.create_image_optimization ? module.next_image[0].cloudfront_origin : null, {
         create = var.create_image_optimization
     })
   }


### PR DESCRIPTION
Replacing deprecated cloudfront_origin_image_optimizer with cloudfront_origin in the module terraform-aws-next-js-image-optimization, since it is a breaking change as stated here https://github.com/milliHQ/terraform-aws-next-js-image-optimization/releases/tag/v12.0.0.

Fixes #243 