### PR TITLE
feat: optionally allow attaching a waf policy to cdn

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -393,6 +393,7 @@ module "cloudfront_main" {
   cloudfront_aliases                  = var.cloudfront_aliases
   cloudfront_acm_certificate_arn      = var.cloudfront_acm_certificate_arn
   cloudfront_minimum_protocol_version = var.cloudfront_minimum_protocol_version
+  cloudfront_webacl_id                = var.cloudfront_webacl_id
 
   cloudfront_default_root_object     = local.cloudfront_default_root_object
   cloudfront_origins                 = local.cloudfront_origins

--- a/modules/cloudfront-main/main.tf
+++ b/modules/cloudfront-main/main.tf
@@ -5,6 +5,7 @@ resource "aws_cloudfront_distribution" "distribution" {
   price_class         = var.cloudfront_price_class
   aliases             = var.cloudfront_aliases
   default_root_object = var.cloudfront_default_root_object
+  web_acl_id          = var.cloudfront_webacl_id
 
   # Add CloudFront origins
   dynamic "origin" {

--- a/modules/cloudfront-main/variables.tf
+++ b/modules/cloudfront-main/variables.tf
@@ -45,6 +45,12 @@ variable "cloudfront_custom_error_response" {
   default = null
 }
 
+variable "cloudfront_webacl_id" {
+  description = "An optional webacl2 arn or webacl id to associate with the cloudfront distribution"
+  type        = string
+  default     = null
+}
+
 ##########
 # Labeling
 ##########

--- a/variables.tf
+++ b/variables.tf
@@ -146,6 +146,12 @@ variable "cloudfront_external_arn" {
   default     = null
 }
 
+variable "cloudfront_webacl_id" {
+  description = "An optional webacl2 arn or webacl id to associate with the cloudfront distribution"
+  type        = string
+  default     = null
+}
+
 ##########
 # Labeling
 ##########


### PR DESCRIPTION
This PR exposes the webacl param on the cloudfront distribution allowing you to pass a waf acl in to do things like restrict traffic from certain ip's or perform application security scanning at the edge