### PR TITLE
Fixes cloudfront invalidation dynamic routing paths

### DIFF
--- a/packages/deploy-trigger/src/__test__/update-manifest.test.ts
+++ b/packages/deploy-trigger/src/__test__/update-manifest.test.ts
@@ -269,12 +269,13 @@ describe('deploy-trigger', () => {
 
 describe('[deploy-trigger] getInvalidationKeys', () => {
   test.each([
-    ['test/[slug]', 'test*'],
-    ['test/[slug]/abc', 'test*'],
-    ['test/[...slug]', 'test*'],
-    ['test/[[...slug]]', 'test*'],
-    ['test/[testId]/index', 'test*'],
-    ['test/[testId]/[otherId]', 'test*'],
+    ['test', '/test*'],
+    ['test/[slug]', '/test*'],
+    ['test/[slug]/abc', '/test*'],
+    ['test/[...slug]', '/test*'],
+    ['test/[[...slug]]', '/test*'],
+    ['test/[testId]/index', '/test*'],
+    ['test/[testId]/[otherId]', '/test*'],
   ])('Generated invalidationKey from %s should be %s', (input, output) => {
     const invalidationKeys = getInvalidationKeys([input]);
 

--- a/packages/deploy-trigger/src/update-manifest.ts
+++ b/packages/deploy-trigger/src/update-manifest.ts
@@ -116,7 +116,7 @@ function getInvalidationKeys(files: string[]) {
     // e.g. - [abc]/index       ->  *
     //      - test/[...slug]    ->  test/*
     if (file.match(dynamicPartMatcher)) {
-      invalidations.push(file.replace(dynamicPartMatcher, '*'));
+      invalidations.push(`/${file.replace(dynamicPartMatcher, '*')}`);
       continue;
     }
 


### PR DESCRIPTION
This PR fixes an error in the Lambda function of deploy-trigger.
There was an error during Cloudfront invalidation, and after checking the AWS documentation, I found that the specification was to pass absolute paths, not relative paths.

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html#invalidation-specifying-objects-paths

## Stacktrace
```
2022-01-15T15:47:37.959Z	e2653e29-84ec-4192-9f19-cf60b77629d4	INFO	InvalidArgument: Your request contains one or more invalid invalidation paths.
    at Request.extractError (/var/runtime/node_modules/aws-sdk/lib/protocol/rest_xml.js:53:29)
    at Request.callListeners (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
    at Request.emit (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
    at Request.emit (/var/runtime/node_modules/aws-sdk/lib/request.js:688:14)
    at Request.transition (/var/runtime/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/var/runtime/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /var/runtime/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/var/runtime/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/var/runtime/node_modules/aws-sdk/lib/request.js:690:12)
    at Request.callListeners (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:116:18)
    at Request.emit (/var/runtime/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
    at Request.emit (/var/runtime/node_modules/aws-sdk/lib/request.js:688:14)
    at Request.transition (/var/runtime/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/var/runtime/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /var/runtime/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/var/runtime/node_modules/aws-sdk/lib/request.js:38:9) {
  code: 'InvalidArgument',
  time: 2022-01-15T15:47:37.955Z,
  requestId: 'b154ef84-c4c4-4623-bda9-3dd0c9de75bd',
  statusCode: 400,
  retryable: false,
  retryDelay: 99.8402518545916
}
```

