### PR TITLE
fix: use relative path as lambda function local package path

### DIFF
--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -1,6 +1,6 @@
 module "proxy_package" {
   source  = "milliHQ/download/npm"
-  version = "2.0.0"
+  version = "2.1.0"
 
   module_name    = "@millihq/terraform-next-proxy"
   module_version = var.proxy_module_version
@@ -26,7 +26,7 @@ module "edge_proxy" {
   role_permissions_boundary = var.lambda_role_permissions_boundary
 
   create_package         = false
-  local_existing_package = module.proxy_package.abs_path
+  local_existing_package = module.proxy_package.rel_path
 
   cloudwatch_logs_retention_in_days = 30
 

--- a/modules/statics-deploy/main.tf
+++ b/modules/statics-deploy/main.tf
@@ -161,7 +161,7 @@ data "aws_iam_policy_document" "access_sqs_queue" {
 
 module "lambda_content" {
   source  = "milliHQ/download/npm"
-  version = "2.0.0"
+  version = "2.1.0"
 
   module_name    = "@millihq/terraform-next-deploy-trigger"
   module_version = var.deploy_trigger_module_version
@@ -185,7 +185,7 @@ module "deploy_trigger" {
   role_permissions_boundary = var.lambda_role_permissions_boundary
 
   create_package         = false
-  local_existing_package = module.lambda_content.abs_path
+  local_existing_package = module.lambda_content.rel_path
 
   # Prevent running concurrently
   reserved_concurrent_executions = 1


### PR DESCRIPTION
To avoid unintentional state changes when working in multiple environments,
Use relative path as lambda function local package path.

Before:
```
# module.tf_next.module.statics_deploy.module.deploy_trigger.aws_lambda_function.this[0] will be created
  + resource "aws_lambda_function" "this" {
      ...
      + filename                       = "/Users/aluc/projects/terraform-aws-next-js/examples/complete/.terraform/modules/tf_next.statics_deploy.lambda_content/download/@millihq/terraform-next-deploy-trigger/dist.zip"
      ...

  # module.tf_next.module.proxy.module.edge_proxy.aws_lambda_function.this[0] will be created
  + resource "aws_lambda_function" "this" {
      ...
      + filename                       = "/Users/aluc/projects/terraform-aws-next-js/examples/complete/.terraform/modules/tf_next.proxy.proxy_package/download/@millihq/terraform-next-proxy/dist.zip"
      ...
```

As seen in `Before`, if the filename is set to an absolute path, the username is included, and the lambda function is updated even if it is the same source in another user's environment.

After:
```
# module.tf_next.aws_lambda_function.this["__NEXT_PAGE_LAMBDA_0"] will be created
  + resource "aws_lambda_function" "this" {
      ...
      + filename                       = "./.next-tf/lambdas/__NEXT_PAGE_LAMBDA_0.zip"
      ...

  # module.tf_next.module.statics_deploy.module.deploy_trigger.aws_lambda_function.this[0] will be created
  + resource "aws_lambda_function" "this" {
      ...
      + filename                       = ".terraform/modules/tf_next.statics_deploy.lambda_content/download/@millihq/terraform-next-deploy-trigger/dist.zip"
      ...
```

In `After`, setting the relative path based on cwd, update is attempted only when the actual source code is changed.

**PR of other related projects:**
- https://github.com/milliHQ/terraform-npm-download/pull/6
- https://github.com/milliHQ/terraform-aws-next-js-image-optimization/pull/98