### PR TITLE
Update function to retrieve s3 endpoint from region

### DIFF
--- a/modules/statics-deploy/s3-bash4/lib/s3-common.sh
+++ b/modules/statics-deploy/s3-bash4/lib/s3-common.sh
@@ -187,7 +187,7 @@ convS3RegionToEndpoint() {
   case "$1" in
     us-east-1) echo "s3.amazonaws.com"
       ;;
-    *) echo s3-${1}.amazonaws.com
+    *) echo s3.${1}.amazonaws.com
       ;;
     esac
 }


### PR DESCRIPTION
Hi,

Using my region `eu-south-1` during `terraform apply` aws thrown an `400` error caused by 

> curl: (6) Could not resolve host: │ s3-eu-south-1.amazonaws.com

Digging in [AWS S3 Doc](https://docs.aws.amazon.com/general/latest/gr/s3.html) the s3 endpoint use this format `s3.{region}.amazonaws.com` maybe it's a recent change and latest region have only this endpoint