### PR TITLE
feat: support response headers policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -332,8 +332,9 @@ locals {
       compress               = true
       viewer_protocol_policy = "redirect-to-https"
 
-      origin_request_policy_id = var.cloudfront_origin_request_policy != null ? var.cloudfront_origin_request_policy : data.aws_cloudfront_origin_request_policy.managed_all_viewer.id
-      cache_policy_id          = aws_cloudfront_cache_policy.this.id
+      origin_request_policy_id   = var.cloudfront_origin_request_policy != null ? var.cloudfront_origin_request_policy : data.aws_cloudfront_origin_request_policy.managed_all_viewer.id
+      response_headers_policy_id = var.cloudfront_response_headers_policy
+      cache_policy_id            = aws_cloudfront_cache_policy.this.id
 
       lambda_function_association = {
         event_type   = "origin-request"

--- a/modules/cloudfront-main/main.tf
+++ b/modules/cloudfront-main/main.tf
@@ -70,8 +70,9 @@ resource "aws_cloudfront_distribution" "distribution" {
       viewer_protocol_policy = default_cache_behavior.value["viewer_protocol_policy"]
       compress               = default_cache_behavior.value["compress"]
 
-      origin_request_policy_id = default_cache_behavior.value["origin_request_policy_id"]
-      cache_policy_id          = default_cache_behavior.value["cache_policy_id"]
+      origin_request_policy_id   = default_cache_behavior.value["origin_request_policy_id"]
+      response_headers_policy_id = default_cache_behavior.value["response_headers_policy_id"]
+      cache_policy_id            = default_cache_behavior.value["cache_policy_id"]
 
       dynamic "lambda_function_association" {
         for_each = [default_cache_behavior.value["lambda_function_association"]]

--- a/variables.tf
+++ b/variables.tf
@@ -128,6 +128,12 @@ variable "cloudfront_origin_request_policy" {
   default     = null
 }
 
+variable "cloudfront_response_headers_policy" {
+  description = "Id of a response headers policy. Can be custom or managed. Default is empty."
+  type        = string
+  default     = null
+}
+
 variable "cloudfront_cache_key_headers" {
   description = "Header keys that should be used to calculate the cache key in CloudFront."
   type        = list(string)


### PR DESCRIPTION
#262 Tested based on project examples on my aws account and works as expected! 

Thanks for reviewing!
```terraform
data "aws_cloudfront_response_headers_policy" "managed_security_headers" {
  name = "Managed-SecurityHeadersPolicy"
}

module "tf_next" {
  source = "milliHQ/next-js/aws"

  deployment_name                    = "tf-next-example-complete"
  cloudfront_response_headers_policy = data.aws_cloudfront_response_headers_policy.managed_security_headers.id
```