### PR TITLE
Bump required aws provider from 3.43.0 to 3.64.0

### DIFF
--- a/modules/cloudfront-main/versions.tf
+++ b/modules/cloudfront-main/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0"
+      version = ">= 3.64.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 3.43.0"
+      version               = ">= 3.64.0"
       configuration_aliases = [aws.global_region]
     }
   }


### PR DESCRIPTION
For using `response_headers_policy_id` which was introduced in #265.

Follow-up: #265
x-ref: https://github.com/hashicorp/terraform-provider-aws/issues/21613