### PR TITLE
chore: add output.lambda_execution_role_arns

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -44,3 +44,12 @@ output "cloudfront_custom_error_response" {
   description = "Preconfigured custom error response the CloudFront distribution should use."
   value       = local.cloudfront_custom_error_response
 }
+
+#####################
+# IAM role for Lambda
+#####################
+
+output "lambda_execution_role_arns" {
+  description = "Lambda execution IAM Role ARNs"
+  value       = { for k, v in local.lambdas : k => aws_iam_role.lambda[k].arn }
+}


### PR DESCRIPTION
When using KMS key, we need to specify lambda role ARN in KMS key policy like below:

```tf
resource "aws_kms_key" "mykey" {
  description = "KMS Key for secureString in ParameterStore"
  policy = jsonencode({
    Version = "2012-10-17"
    Statement = [
      {
        Effect = "Allow"
        Principal = {
          "AWS" = values(module.tf_next.lambda_execution_role_arns)
        }
        Action = ["kms:Encrypt", "kms:Decrypt"]
        Resource = "*"
      },
    ]
  })
}

module "tf_next" { ... }
```

So I added this `lambda_execution_role_arns` output.