### PR TITLE
Bugfix additional policy documents

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -83,7 +83,7 @@ resource "aws_iam_role_policy_attachment" "lambda_vpc" {
 ####################################
 
 resource "aws_iam_policy" "additional_json" {
-  count = var.create_lambda_policy ? 1 : 0
+  count = var.lambda_attach_policy_json ? 1 : 0
 
   description = "Managed by Terraform Next.js"
   policy      = var.lambda_policy_json
@@ -92,7 +92,7 @@ resource "aws_iam_policy" "additional_json" {
 }
 
 resource "aws_iam_role_policy_attachment" "additional_json" {
-  for_each = var.create_lambda_policy != null ? local.lambdas : {}
+  for_each = var.lambda_attach_policy_json ? local.lambdas : {}
 
   role       = aws_iam_role.lambda[each.key].name
   policy_arn = aws_iam_policy.additional_json[0].arn

--- a/iam.tf
+++ b/iam.tf
@@ -83,7 +83,7 @@ resource "aws_iam_role_policy_attachment" "lambda_vpc" {
 ####################################
 
 resource "aws_iam_policy" "additional_json" {
-  count = var.lambda_policy_json != null ? 1 : 0
+  count = var.create_lambda_policy ? 1 : 0
 
   description = "Managed by Terraform Next.js"
   policy      = var.lambda_policy_json
@@ -92,7 +92,7 @@ resource "aws_iam_policy" "additional_json" {
 }
 
 resource "aws_iam_role_policy_attachment" "additional_json" {
-  for_each = var.lambda_policy_json != null ? local.lambdas : {}
+  for_each = var.create_lambda_policy != null ? local.lambdas : {}
 
   role       = aws_iam_role.lambda[each.key].name
   policy_arn = aws_iam_policy.additional_json[0].arn

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,12 @@ variable "lambda_policy_json" {
   default     = null
 }
 
+variable "create_lambda_policy" {
+  description = "Whether to deploy additional lambda JSON policies. If false, lambda_policy_json will not be attached to the lambda function. (Necessary since policy strings are only known after apply when using Terraforms data.aws_iam_policy_document)"
+  type        = bool
+  default     = false
+}
+
 variable "lambda_role_permissions_boundary" {
   type = string
   # https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html

--- a/variables.tf
+++ b/variables.tf
@@ -64,7 +64,7 @@ variable "lambda_policy_json" {
   default     = null
 }
 
-variable "create_lambda_policy" {
+variable "lambda_attach_policy_json" {
   description = "Whether to deploy additional lambda JSON policies. If false, lambda_policy_json will not be attached to the lambda function. (Necessary since policy strings are only known after apply when using Terraforms data.aws_iam_policy_document)"
   type        = bool
   default     = false


### PR DESCRIPTION
Add boolean to determine whether we should create additional lambda policies since checking for a json string will fail when using data.aws_iam_policy_document. 