### PR TITLE
Fix: Extract fileExt before determine content-type

### DIFF
--- a/packages/deploy-trigger/src/__test__/deploy-trigger.test.ts
+++ b/packages/deploy-trigger/src/__test__/deploy-trigger.test.ts
@@ -43,8 +43,14 @@ describe('deploy-trigger', () => {
     test('Extract an uploaded deployment', async () => {
       const packageKey = 'static-website-files.zip';
       const staticRouteKey = '404';
+      const localeStaticRouteKey = 'es';
       const staticAssetKey = '_next/static/some.js';
-      const packageContent = ['index', staticRouteKey, staticAssetKey];
+      const packageContent = [
+        'index',
+        localeStaticRouteKey,
+        staticRouteKey,
+        staticAssetKey,
+      ];
 
       // Create an dummy deployment package
       const bundle = await generateZipBundle(packageContent);
@@ -84,6 +90,21 @@ describe('deploy-trigger', () => {
           ])
         );
       }
+
+      // Check the mime-type and Cache-Control headers
+      const localeStaticRouteObject = await s3
+        .getObject({
+          Bucket: targetBucket.bucketName,
+          Key: localeStaticRouteKey,
+        })
+        .promise();
+
+      expect(localeStaticRouteObject.ContentType).toBe(
+        'text/html; charset=utf-8'
+      );
+      expect(localeStaticRouteObject.CacheControl).toBe(
+        'public,max-age=0,must-revalidate,s-maxage=31536000'
+      );
 
       // Check the mime-type and Cache-Control headers
       const staticRouteObject = await s3

--- a/packages/deploy-trigger/src/deploy-trigger.ts
+++ b/packages/deploy-trigger/src/deploy-trigger.ts
@@ -1,3 +1,5 @@
+import { extname } from 'path';
+
 import { S3 } from 'aws-sdk';
 import unzipper from 'unzipper';
 import {
@@ -85,7 +87,10 @@ export async function deployTrigger({
       // Get ContentType
       // Static pre-rendered pages have no file extension,
       // files without extension get HTML mime type as fallback
-      const mimeType = mimeLookup(fileName);
+      //
+      // Explicitly use the extname here since mime treats files without
+      // extension e.g. `/es` as extension => `application/ecmascript`
+      const mimeType = mimeLookup(extname(fileName));
       const contentType =
         typeof mimeType === 'string' ? mimeContentType(mimeType) : false;
 


### PR DESCRIPTION
When using localised paths like `/es`, `mime-types` assumes `es` as file extension.
This causes that `/es` gets the wrong content-type assigned `application/ecmascript` instead of `text/html`.

Fixes #277.