### PR TITLE
Bump @vercel/build-utils from 2.10.1 to 2.12.1

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -26,7 +26,7 @@
     "@types/resolve-from": "5.0.1",
     "@types/semver": "6.0.0",
     "@types/yazl": "2.4.1",
-    "@vercel/build-utils": "2.10.1",
+    "@vercel/build-utils": "2.12.1",
     "@vercel/nft": "0.10.0",
     "@vercel/routing-utils": "1.10.1",
     "async-sema": "3.0.1",

--- a/packages/tf-next/package.json
+++ b/packages/tf-next/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@millihq/tf-next-runtime": "0.11.4",
-    "@vercel/build-utils": "2.10.1",
+    "@vercel/build-utils": "2.12.1",
     "@vercel/frameworks": "^0.0.15",
     "@vercel/routing-utils": "^1.10.1",
     "archiver": "^5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1352,10 +1352,10 @@
   dependencies:
     "@types/node" "*"
 
-"@vercel/build-utils@2.10.1":
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/@vercel/build-utils/-/build-utils-2.10.1.tgz#5b175fc66639a82f8beeb19e85983fe955f27875"
-  integrity sha512-K5xaXoZnysKXxuc5YuR9NZxzBaS9UZYI+TGQCrpx+n1jFJMnVKcXTIlcGtsbNzVI1PR8Fx7YgjtAChSoIyBznQ==
+"@vercel/build-utils@2.12.1":
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/@vercel/build-utils/-/build-utils-2.12.1.tgz#479a7eb0111985ff437d77dd395bb9ba6d108c95"
+  integrity sha512-85FUGmNQWL+gWORGIfW2amNeDt3vBgliZ51j3D9s+2qcAv+Li+ghLfzjoP5w5E+DhO8OxHfy53WbqR5aprAWEA==
 
 "@vercel/frameworks@^0.0.15":
   version "0.0.15"


### PR DESCRIPTION
This could fix compatibility with npm 7 workspaces, according to https://github.com/milliHQ/terraform-aws-next-js/issues/135#issuecomment-1046371092. 