### PR TITLE
Restrict image optimizer version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -148,7 +148,7 @@ module "next_image" {
   count = var.create_image_optimization ? 1 : 0
 
   source  = "milliHQ/next-js-image-optimization/aws"
-  version = ">= 11.0.0"
+  version = "~> 12.0.10"
 
   cloudfront_create_distribution = false
 


### PR DESCRIPTION
This restricts the version of the [Image Optimization submodule](https://github.com/milliHQ/terraform-aws-next-js-image-optimization) to `<= 12.0.10`.

This is necessary since `12.0.10` is the last version with support for the 3.x version of the Terraform AWS provider.
The next minor version of this will use 4.x and so will the Image Optimization module.

To avoid a break of existing setups, this is a compatibility release that ensures installations with 3.x AWS provider will not break.