### PR TITLE
Append querystring to redirects

### DIFF
--- a/packages/proxy/src/util/append-querystring.ts
+++ b/packages/proxy/src/util/append-querystring.ts
@@ -1,0 +1,31 @@
+import { URL, URLSearchParams } from 'url';
+
+import isURL from './is-url';
+
+/**
+ * Append a querystring to a relative or absolute URL.
+ * Already existing searchParams are not overridden by the new searchParams.
+ *
+ * @param url The relative or absolute URL
+ * @param searchParams The searchParams that should be merged with the input URL
+ */
+function appendQuerystring(url: string, searchParams: URLSearchParams): string {
+  const urlObj = new URL(url, 'https://n');
+  const combinedSearchParams = new URLSearchParams({
+    ...Object.fromEntries(searchParams),
+    ...Object.fromEntries(urlObj.searchParams),
+  }).toString();
+
+  if (combinedSearchParams == '') {
+    return url;
+  }
+
+  if (isURL(url)) {
+    urlObj.search = '';
+    return `${urlObj.toString()}?${combinedSearchParams}`;
+  }
+
+  return `${urlObj.pathname}?${combinedSearchParams}`;
+}
+
+export { appendQuerystring };

--- a/packages/proxy/test/handler.test.ts
+++ b/packages/proxy/test/handler.test.ts
@@ -413,6 +413,7 @@ describe('[proxy] Handler', () => {
     // Prepare configServer
     configServer.proxyConfig = proxyConfig;
     const cloudFrontEvent = generateCloudFrontRequestEvent({
+      apiGatewayEndpoint: 'api-gateway.local',
       configEndpoint,
       uri: requestPath,
     });

--- a/packages/proxy/test/handler.test.ts
+++ b/packages/proxy/test/handler.test.ts
@@ -1,11 +1,10 @@
 import { createServer, Server } from 'http';
-import { CloudFrontRequestEvent, CloudFrontRequest } from 'aws-lambda';
+
+import { CloudFrontRequest } from 'aws-lambda';
 import getPort from 'get-port';
 
 import { ProxyConfig } from '../src/types';
-
-// Max runtime of the lambda
-const TIMEOUT = 30000;
+import { generateCloudFrontRequestEvent } from './test-utils';
 
 class ConfigServer {
   public proxyConfig?: ProxyConfig;
@@ -58,1175 +57,694 @@ describe('[proxy] Handler', () => {
     await configServer.stop();
   });
 
-  test(
-    'External redirect [HTTP]',
-    async () => {
-      const proxyConfig: ProxyConfig = {
-        lambdaRoutes: [],
-        prerenders: {},
-        staticRoutes: [],
-        routes: [
+  test('External redirect [HTTP]', async () => {
+    const proxyConfig: ProxyConfig = {
+      lambdaRoutes: [],
+      prerenders: {},
+      staticRoutes: [],
+      routes: [
+        {
+          src: '^\\/docs(?:\\/([^\\/]+?))$',
+          dest: 'http://example.com/docs/$1',
+          check: true,
+        },
+      ],
+    };
+    const requestPath = '/docs/hello-world';
+
+    // Prepare configServer
+    configServer.proxyConfig = proxyConfig;
+
+    const cloudFrontEvent = generateCloudFrontRequestEvent({
+      configEndpoint,
+      uri: requestPath,
+    });
+    const result = (await handler(cloudFrontEvent)) as CloudFrontRequest;
+
+    expect(result.origin?.custom).toEqual(
+      expect.objectContaining({
+        domainName: 'example.com',
+        path: '',
+        port: 80,
+        protocol: 'http',
+      })
+    );
+    expect(result.uri).toBe('/docs/hello-world');
+    expect(result.headers.host).toEqual(
+      expect.arrayContaining([
+        {
+          key: 'host',
+          value: 'example.com',
+        },
+      ])
+    );
+  });
+
+  test('External redirect [HTTPS]', async () => {
+    const proxyConfig: ProxyConfig = {
+      lambdaRoutes: [],
+      prerenders: {},
+      staticRoutes: [],
+      routes: [
+        {
+          src: '^\\/docs(?:\\/([^\\/]+?))$',
+          dest: 'https://example.com/docs/$1',
+          check: true,
+        },
+      ],
+    };
+    const requestPath = '/docs/hello-world';
+
+    // Prepare configServer
+    configServer.proxyConfig = proxyConfig;
+    const cloudFrontEvent = generateCloudFrontRequestEvent({
+      configEndpoint,
+      uri: requestPath,
+    });
+    const result = (await handler(cloudFrontEvent)) as CloudFrontRequest;
+
+    expect(result.origin?.custom).toEqual(
+      expect.objectContaining({
+        domainName: 'example.com',
+        path: '',
+        port: 443,
+        protocol: 'https',
+      })
+    );
+    expect(result.uri).toBe('/docs/hello-world');
+    expect(result.headers.host).toEqual(
+      expect.arrayContaining([
+        {
+          key: 'host',
+          value: 'example.com',
+        },
+      ])
+    );
+  });
+
+  test('External redirect [Custom Port]', async () => {
+    const proxyConfig: ProxyConfig = {
+      lambdaRoutes: [],
+      prerenders: {},
+      staticRoutes: [],
+      routes: [
+        {
+          src: '^\\/docs(?:\\/([^\\/]+?))$',
+          dest: 'https://example.com:666/docs/$1',
+          check: true,
+        },
+      ],
+    };
+    const requestPath = '/docs/hello-world';
+
+    // Prepare configServer
+    configServer.proxyConfig = proxyConfig;
+    const cloudFrontEvent = generateCloudFrontRequestEvent({
+      configEndpoint,
+      uri: requestPath,
+    });
+    const result = (await handler(cloudFrontEvent)) as CloudFrontRequest;
+
+    expect(result.origin?.custom).toEqual(
+      expect.objectContaining({
+        domainName: 'example.com',
+        path: '',
+        port: 666,
+        protocol: 'https',
+      })
+    );
+    expect(result.uri).toBe('/docs/hello-world');
+    expect(result.headers.host).toEqual(
+      expect.arrayContaining([
+        {
+          key: 'host',
+          value: 'example.com',
+        },
+      ])
+    );
+  });
+
+  test('External redirect [Subdomain]', async () => {
+    const proxyConfig: ProxyConfig = {
+      lambdaRoutes: [],
+      prerenders: {},
+      staticRoutes: [],
+      routes: [
+        {
+          src: '^\\/docs(?:\\/([^\\/]+?))$',
+          dest: 'https://sub.example.com/docs/$1',
+          check: true,
+        },
+      ],
+    };
+    const requestPath = '/docs/hello-world';
+
+    // Prepare configServer
+    configServer.proxyConfig = proxyConfig;
+    const cloudFrontEvent = generateCloudFrontRequestEvent({
+      configEndpoint,
+      uri: requestPath,
+    });
+    const result = (await handler(cloudFrontEvent)) as CloudFrontRequest;
+
+    expect(result.origin?.custom).toEqual(
+      expect.objectContaining({
+        domainName: 'sub.example.com',
+        path: '',
+        port: 443,
+        protocol: 'https',
+      })
+    );
+    expect(result.uri).toBe('/docs/hello-world');
+    expect(result.headers.host).toEqual(
+      expect.arrayContaining([
+        {
+          key: 'host',
+          value: 'sub.example.com',
+        },
+      ])
+    );
+  });
+
+  test('i18n default locale rewrite', async () => {
+    const proxyConfig: ProxyConfig = {
+      lambdaRoutes: [],
+      prerenders: {},
+      staticRoutes: [],
+      routes: [
+        {
+          src: '^/(?!(?:_next/.*|en|fr\\-FR|nl)(?:/.*|$))(.*)$',
+          dest: '$wildcard/$1',
+          continue: true,
+        },
+        {
+          src: '/',
+          locale: {
+            redirect: {
+              en: '/',
+              'fr-FR': '/fr-FR',
+              nl: '/nl',
+            },
+            cookie: 'NEXT_LOCALE',
+          },
+          continue: true,
+        },
+        {
+          src: '^/$',
+          dest: '/en',
+          continue: true,
+        },
+      ],
+    };
+    const requestPath = '/';
+
+    // Prepare configServer
+    configServer.proxyConfig = proxyConfig;
+    const cloudFrontEvent = generateCloudFrontRequestEvent({
+      configEndpoint,
+      uri: requestPath,
+    });
+    const result = (await handler(cloudFrontEvent)) as CloudFrontRequest;
+
+    expect(result.origin?.s3).toEqual(
+      expect.objectContaining({
+        domainName: 's3.localhost',
+        path: '',
+      })
+    );
+    expect(result.uri).toBe('/en');
+  });
+
+  test('Correctly request /index object from S3 when requesting /', async () => {
+    const proxyConfig: ProxyConfig = {
+      staticRoutes: ['/404', '/500', '/index'],
+      lambdaRoutes: [],
+      routes: [
+        {
+          src: '^(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/$',
+          headers: {
+            Location: '/$1',
+          },
+          status: 308,
+          continue: true,
+        },
+        {
+          src: '/404',
+          status: 404,
+          continue: true,
+        },
+        {
+          handle: 'filesystem',
+        },
+        {
+          handle: 'resource',
+        },
+        {
+          src: '/.*',
+          status: 404,
+        },
+        {
+          handle: 'miss',
+        },
+        {
+          handle: 'rewrite',
+        },
+        {
+          handle: 'hit',
+        },
+        {
+          handle: 'error',
+        },
+        {
+          src: '/.*',
+          dest: '/404',
+          status: 404,
+        },
+      ],
+      prerenders: {},
+    };
+
+    const requestPath = '/';
+
+    // Prepare configServer
+    configServer.proxyConfig = proxyConfig;
+    const cloudFrontEvent = generateCloudFrontRequestEvent({
+      configEndpoint,
+      uri: requestPath,
+    });
+    const result = (await handler(cloudFrontEvent)) as CloudFrontRequest;
+
+    expect(result.origin?.s3).toEqual(
+      expect.objectContaining({
+        domainName: 's3.localhost',
+        path: '',
+      })
+    );
+    expect(result.uri).toBe('/index');
+  });
+
+  test('Add x-forwarded-host header to API-Gateway requests', async () => {
+    const hostHeader = 'example.org';
+    const proxyConfig: ProxyConfig = {
+      lambdaRoutes: ['/__NEXT_API_LAMBDA_0'],
+      prerenders: {},
+      staticRoutes: [],
+      routes: [
+        {
+          src: '^(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/$',
+          headers: {
+            Location: '/$1',
+          },
+          status: 308,
+          continue: true,
+        },
+        {
+          src: '/404',
+          status: 404,
+          continue: true,
+        },
+        {
+          handle: 'filesystem',
+        },
+        {
+          src: '^/api/test/?$',
+          dest: '/__NEXT_API_LAMBDA_0',
+          headers: {
+            'x-nextjs-page': '/api/test',
+          },
+          check: true,
+        },
+        {
+          handle: 'resource',
+        },
+        {
+          src: '/.*',
+          status: 404,
+        },
+        {
+          handle: 'miss',
+        },
+        {
+          handle: 'rewrite',
+        },
+        {
+          src: '^/api/test/?$',
+          dest: '/__NEXT_API_LAMBDA_0',
+          headers: {
+            'x-nextjs-page': '/api/test',
+          },
+          check: true,
+        },
+        {
+          handle: 'hit',
+        },
+        {
+          handle: 'error',
+        },
+        {
+          src: '/.*',
+          dest: '/404',
+          status: 404,
+        },
+      ],
+    };
+    const requestPath = '/api/test';
+
+    // Prepare configServer
+    configServer.proxyConfig = proxyConfig;
+    const cloudFrontEvent = generateCloudFrontRequestEvent({
+      configEndpoint,
+      uri: requestPath,
+    });
+    const result = (await handler(cloudFrontEvent)) as CloudFrontRequest;
+
+    expect(result.origin?.custom).toEqual(
+      expect.objectContaining({
+        domainName: 'api-gateway.local',
+        path: '/__NEXT_API_LAMBDA_0',
+      })
+    );
+    expect(result.headers).toEqual(
+      expect.objectContaining({
+        'x-nextjs-page': [
           {
-            src: '^\\/docs(?:\\/([^\\/]+?))$',
-            dest: 'http://example.com/docs/$1',
-            check: true,
+            key: 'x-nextjs-page',
+            value: '/api/test',
           },
         ],
-      };
-      const requestPath = '/docs/hello-world';
-
-      // Prepare configServer
-      configServer.proxyConfig = proxyConfig;
-
-      // Origin Request
-      // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#example-origin-request
-      const event: CloudFrontRequestEvent = {
-        Records: [
+        'x-forwarded-host': [
           {
-            cf: {
-              config: {
-                distributionDomainName: 'd111111abcdef8.cloudfront.net',
-                distributionId: 'EDFDVBD6EXAMPLE',
-                eventType: 'origin-request',
-                requestId:
-                  '4TyzHTaYWb1GX1qTfsHhEqV6HUDd_BzoBZnwfnvQc_1oF26ClkoUSEQ==',
-              },
-              request: {
-                clientIp: '203.0.113.178',
-                headers: {
-                  'x-forwarded-for': [
-                    {
-                      key: 'X-Forwarded-For',
-                      value: '203.0.113.178',
-                    },
-                  ],
-                  'user-agent': [
-                    {
-                      key: 'User-Agent',
-                      value: 'Amazon CloudFront',
-                    },
-                  ],
-                  via: [
-                    {
-                      key: 'Via',
-                      value:
-                        '2.0 2afae0d44e2540f472c0635ab62c232b.cloudfront.net (CloudFront)',
-                    },
-                  ],
-                  host: [
-                    {
-                      key: 'Host',
-                      value: 'example.org',
-                    },
-                  ],
-                  'cache-control': [
-                    {
-                      key: 'Cache-Control',
-                      value: 'no-cache, cf-no-cache',
-                    },
-                  ],
-                },
-                method: 'GET',
-                origin: {
-                  s3: {
-                    customHeaders: {
-                      'x-env-config-endpoint': [
-                        {
-                          key: 'x-env-config-endpoint',
-                          value: configEndpoint,
-                        },
-                      ],
-                      'x-env-api-endpoint': [
-                        {
-                          key: 'x-env-api-endpoint',
-                          value: 'example.localhost',
-                        },
-                      ],
-                    },
-                    region: 'us-east-1',
-                    authMethod: 'origin-access-identity',
-                    domainName: 's3.localhost',
-                    path: '',
-                  },
-                },
-                querystring: '',
-                uri: requestPath,
-              },
-            },
+            key: 'X-Forwarded-Host',
+            value: hostHeader,
           },
         ],
-      };
-
-      const result = (await handler(event)) as CloudFrontRequest;
-
-      expect(result.origin?.custom).toEqual(
-        expect.objectContaining({
-          domainName: 'example.com',
-          path: '',
-          port: 80,
-          protocol: 'http',
-        })
-      );
-      expect(result.uri).toBe('/docs/hello-world');
-      expect(result.headers.host).toEqual(
-        expect.arrayContaining([
-          {
-            key: 'host',
-            value: 'example.com',
-          },
-        ])
-      );
-    },
-    TIMEOUT
-  );
-
-  test(
-    'External redirect [HTTPS]',
-    async () => {
-      const proxyConfig: ProxyConfig = {
-        lambdaRoutes: [],
-        prerenders: {},
-        staticRoutes: [],
-        routes: [
-          {
-            src: '^\\/docs(?:\\/([^\\/]+?))$',
-            dest: 'https://example.com/docs/$1',
-            check: true,
-          },
-        ],
-      };
-      const requestPath = '/docs/hello-world';
-
-      // Prepare configServer
-      configServer.proxyConfig = proxyConfig;
-
-      // Origin Request
-      // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#example-origin-request
-      const event: CloudFrontRequestEvent = {
-        Records: [
-          {
-            cf: {
-              config: {
-                distributionDomainName: 'd111111abcdef8.cloudfront.net',
-                distributionId: 'EDFDVBD6EXAMPLE',
-                eventType: 'origin-request',
-                requestId:
-                  '4TyzHTaYWb1GX1qTfsHhEqV6HUDd_BzoBZnwfnvQc_1oF26ClkoUSEQ==',
-              },
-              request: {
-                clientIp: '203.0.113.178',
-                headers: {
-                  'x-forwarded-for': [
-                    {
-                      key: 'X-Forwarded-For',
-                      value: '203.0.113.178',
-                    },
-                  ],
-                  'user-agent': [
-                    {
-                      key: 'User-Agent',
-                      value: 'Amazon CloudFront',
-                    },
-                  ],
-                  via: [
-                    {
-                      key: 'Via',
-                      value:
-                        '2.0 2afae0d44e2540f472c0635ab62c232b.cloudfront.net (CloudFront)',
-                    },
-                  ],
-                  host: [
-                    {
-                      key: 'Host',
-                      value: 'example.org',
-                    },
-                  ],
-                  'cache-control': [
-                    {
-                      key: 'Cache-Control',
-                      value: 'no-cache, cf-no-cache',
-                    },
-                  ],
-                },
-                method: 'GET',
-                origin: {
-                  s3: {
-                    customHeaders: {
-                      'x-env-config-endpoint': [
-                        {
-                          key: 'x-env-config-endpoint',
-                          value: configEndpoint,
-                        },
-                      ],
-                      'x-env-api-endpoint': [
-                        {
-                          key: 'x-env-api-endpoint',
-                          value: 'example.localhost',
-                        },
-                      ],
-                    },
-                    region: 'us-east-1',
-                    authMethod: 'origin-access-identity',
-                    domainName: 's3.localhost',
-                    path: '',
-                  },
-                },
-                querystring: '',
-                uri: requestPath,
-              },
-            },
-          },
-        ],
-      };
-
-      const result = (await handler(event)) as CloudFrontRequest;
-
-      expect(result.origin?.custom).toEqual(
-        expect.objectContaining({
-          domainName: 'example.com',
-          path: '',
-          port: 443,
-          protocol: 'https',
-        })
-      );
-      expect(result.uri).toBe('/docs/hello-world');
-      expect(result.headers.host).toEqual(
-        expect.arrayContaining([
-          {
-            key: 'host',
-            value: 'example.com',
-          },
-        ])
-      );
-    },
-    TIMEOUT
-  );
-
-  test(
-    'External redirect [Custom Port]',
-    async () => {
-      const proxyConfig: ProxyConfig = {
-        lambdaRoutes: [],
-        prerenders: {},
-        staticRoutes: [],
-        routes: [
-          {
-            src: '^\\/docs(?:\\/([^\\/]+?))$',
-            dest: 'https://example.com:666/docs/$1',
-            check: true,
-          },
-        ],
-      };
-      const requestPath = '/docs/hello-world';
-
-      // Prepare configServer
-      configServer.proxyConfig = proxyConfig;
-
-      // Origin Request
-      // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#example-origin-request
-      const event: CloudFrontRequestEvent = {
-        Records: [
-          {
-            cf: {
-              config: {
-                distributionDomainName: 'd111111abcdef8.cloudfront.net',
-                distributionId: 'EDFDVBD6EXAMPLE',
-                eventType: 'origin-request',
-                requestId:
-                  '4TyzHTaYWb1GX1qTfsHhEqV6HUDd_BzoBZnwfnvQc_1oF26ClkoUSEQ==',
-              },
-              request: {
-                clientIp: '203.0.113.178',
-                headers: {
-                  'x-forwarded-for': [
-                    {
-                      key: 'X-Forwarded-For',
-                      value: '203.0.113.178',
-                    },
-                  ],
-                  'user-agent': [
-                    {
-                      key: 'User-Agent',
-                      value: 'Amazon CloudFront',
-                    },
-                  ],
-                  via: [
-                    {
-                      key: 'Via',
-                      value:
-                        '2.0 2afae0d44e2540f472c0635ab62c232b.cloudfront.net (CloudFront)',
-                    },
-                  ],
-                  host: [
-                    {
-                      key: 'Host',
-                      value: 'example.org',
-                    },
-                  ],
-                  'cache-control': [
-                    {
-                      key: 'Cache-Control',
-                      value: 'no-cache, cf-no-cache',
-                    },
-                  ],
-                },
-                method: 'GET',
-                origin: {
-                  s3: {
-                    customHeaders: {
-                      'x-env-config-endpoint': [
-                        {
-                          key: 'x-env-config-endpoint',
-                          value: configEndpoint,
-                        },
-                      ],
-                      'x-env-api-endpoint': [
-                        {
-                          key: 'x-env-api-endpoint',
-                          value: 'example.localhost',
-                        },
-                      ],
-                    },
-                    region: 'us-east-1',
-                    authMethod: 'origin-access-identity',
-                    domainName: 's3.localhost',
-                    path: '',
-                  },
-                },
-                querystring: '',
-                uri: requestPath,
-              },
-            },
-          },
-        ],
-      };
-
-      const result = (await handler(event)) as CloudFrontRequest;
-
-      expect(result.origin?.custom).toEqual(
-        expect.objectContaining({
-          domainName: 'example.com',
-          path: '',
-          port: 666,
-          protocol: 'https',
-        })
-      );
-      expect(result.uri).toBe('/docs/hello-world');
-      expect(result.headers.host).toEqual(
-        expect.arrayContaining([
-          {
-            key: 'host',
-            value: 'example.com',
-          },
-        ])
-      );
-    },
-    TIMEOUT
-  );
-
-  test(
-    'External redirect [Subdomain]',
-    async () => {
-      const proxyConfig: ProxyConfig = {
-        lambdaRoutes: [],
-        prerenders: {},
-        staticRoutes: [],
-        routes: [
-          {
-            src: '^\\/docs(?:\\/([^\\/]+?))$',
-            dest: 'https://sub.example.com/docs/$1',
-            check: true,
-          },
-        ],
-      };
-      const requestPath = '/docs/hello-world';
-
-      // Prepare configServer
-      configServer.proxyConfig = proxyConfig;
-
-      // Origin Request
-      // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#example-origin-request
-      const event: CloudFrontRequestEvent = {
-        Records: [
-          {
-            cf: {
-              config: {
-                distributionDomainName: 'd111111abcdef8.cloudfront.net',
-                distributionId: 'EDFDVBD6EXAMPLE',
-                eventType: 'origin-request',
-                requestId:
-                  '4TyzHTaYWb1GX1qTfsHhEqV6HUDd_BzoBZnwfnvQc_1oF26ClkoUSEQ==',
-              },
-              request: {
-                clientIp: '203.0.113.178',
-                headers: {
-                  'x-forwarded-for': [
-                    {
-                      key: 'X-Forwarded-For',
-                      value: '203.0.113.178',
-                    },
-                  ],
-                  'user-agent': [
-                    {
-                      key: 'User-Agent',
-                      value: 'Amazon CloudFront',
-                    },
-                  ],
-                  via: [
-                    {
-                      key: 'Via',
-                      value:
-                        '2.0 2afae0d44e2540f472c0635ab62c232b.cloudfront.net (CloudFront)',
-                    },
-                  ],
-                  host: [
-                    {
-                      key: 'Host',
-                      value: 'example.org',
-                    },
-                  ],
-                  'cache-control': [
-                    {
-                      key: 'Cache-Control',
-                      value: 'no-cache, cf-no-cache',
-                    },
-                  ],
-                },
-                method: 'GET',
-                origin: {
-                  s3: {
-                    customHeaders: {
-                      'x-env-config-endpoint': [
-                        {
-                          key: 'x-env-config-endpoint',
-                          value: configEndpoint,
-                        },
-                      ],
-                      'x-env-api-endpoint': [
-                        {
-                          key: 'x-env-api-endpoint',
-                          value: 'example.localhost',
-                        },
-                      ],
-                    },
-                    region: 'us-east-1',
-                    authMethod: 'origin-access-identity',
-                    domainName: 's3.localhost',
-                    path: '',
-                  },
-                },
-                querystring: '',
-                uri: requestPath,
-              },
-            },
-          },
-        ],
-      };
-
-      const result = (await handler(event)) as CloudFrontRequest;
-
-      expect(result.origin?.custom).toEqual(
-        expect.objectContaining({
-          domainName: 'sub.example.com',
-          path: '',
-          port: 443,
-          protocol: 'https',
-        })
-      );
-      expect(result.uri).toBe('/docs/hello-world');
-      expect(result.headers.host).toEqual(
-        expect.arrayContaining([
-          {
-            key: 'host',
-            value: 'sub.example.com',
-          },
-        ])
-      );
-    },
-    TIMEOUT
-  );
-
-  test(
-    'i18n default locale rewrite',
-    async () => {
-      const proxyConfig: ProxyConfig = {
-        lambdaRoutes: [],
-        prerenders: {},
-        staticRoutes: [],
-        routes: [
-          {
-            src: '^/(?!(?:_next/.*|en|fr\\-FR|nl)(?:/.*|$))(.*)$',
-            dest: '$wildcard/$1',
-            continue: true,
-          },
-          {
-            src: '/',
-            locale: {
-              redirect: {
-                en: '/',
-                'fr-FR': '/fr-FR',
-                nl: '/nl',
-              },
-              cookie: 'NEXT_LOCALE',
-            },
-            continue: true,
-          },
-          {
-            src: '^/$',
-            dest: '/en',
-            continue: true,
-          },
-        ],
-      };
-      const requestPath = '/';
-
-      // Prepare configServer
-      configServer.proxyConfig = proxyConfig;
-
-      // Origin Request
-      // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#example-origin-request
-      const event: CloudFrontRequestEvent = {
-        Records: [
-          {
-            cf: {
-              config: {
-                distributionDomainName: 'd111111abcdef8.cloudfront.net',
-                distributionId: 'EDFDVBD6EXAMPLE',
-                eventType: 'origin-request',
-                requestId:
-                  '4TyzHTaYWb1GX1qTfsHhEqV6HUDd_BzoBZnwfnvQc_1oF26ClkoUSEQ==',
-              },
-              request: {
-                clientIp: '203.0.113.178',
-                headers: {
-                  'x-forwarded-for': [
-                    {
-                      key: 'X-Forwarded-For',
-                      value: '203.0.113.178',
-                    },
-                  ],
-                  'user-agent': [
-                    {
-                      key: 'User-Agent',
-                      value: 'Amazon CloudFront',
-                    },
-                  ],
-                  via: [
-                    {
-                      key: 'Via',
-                      value:
-                        '2.0 2afae0d44e2540f472c0635ab62c232b.cloudfront.net (CloudFront)',
-                    },
-                  ],
-                  host: [
-                    {
-                      key: 'Host',
-                      value: 'example.org',
-                    },
-                  ],
-                  'cache-control': [
-                    {
-                      key: 'Cache-Control',
-                      value: 'no-cache, cf-no-cache',
-                    },
-                  ],
-                },
-                method: 'GET',
-                origin: {
-                  s3: {
-                    customHeaders: {
-                      'x-env-config-endpoint': [
-                        {
-                          key: 'x-env-config-endpoint',
-                          value: configEndpoint,
-                        },
-                      ],
-                      'x-env-api-endpoint': [
-                        {
-                          key: 'x-env-api-endpoint',
-                          value: 'example.localhost',
-                        },
-                      ],
-                    },
-                    region: 'us-east-1',
-                    authMethod: 'origin-access-identity',
-                    domainName: 's3.localhost',
-                    path: '',
-                  },
-                },
-                querystring: '',
-                uri: requestPath,
-              },
-            },
-          },
-        ],
-      };
-
-      const result = (await handler(event)) as CloudFrontRequest;
-
-      expect(result.origin?.s3).toEqual(
-        expect.objectContaining({
-          domainName: 's3.localhost',
-          path: '',
-        })
-      );
-      expect(result.uri).toBe('/en');
-    },
-    TIMEOUT
-  );
-
-  test(
-    'Correctly request /index object from S3 when requesting /',
-    async () => {
-      const proxyConfig: ProxyConfig = {
-        staticRoutes: ['/404', '/500', '/index'],
-        lambdaRoutes: [],
-        routes: [
-          {
-            src: '^(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/$',
-            headers: {
-              Location: '/$1',
-            },
-            status: 308,
-            continue: true,
-          },
-          {
-            src: '/404',
-            status: 404,
-            continue: true,
-          },
-          {
-            handle: 'filesystem',
-          },
-          {
-            handle: 'resource',
-          },
-          {
-            src: '/.*',
-            status: 404,
-          },
-          {
-            handle: 'miss',
-          },
-          {
-            handle: 'rewrite',
-          },
-          {
-            handle: 'hit',
-          },
-          {
-            handle: 'error',
-          },
-          {
-            src: '/.*',
-            dest: '/404',
-            status: 404,
-          },
-        ],
-        prerenders: {},
-      };
-
-      const requestPath = '/';
-
-      // Prepare configServer
-      configServer.proxyConfig = proxyConfig;
-
-      // Origin Request
-      // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#example-origin-request
-      const event: CloudFrontRequestEvent = {
-        Records: [
-          {
-            cf: {
-              config: {
-                distributionDomainName: 'd111111abcdef8.cloudfront.net',
-                distributionId: 'EDFDVBD6EXAMPLE',
-                eventType: 'origin-request',
-                requestId:
-                  '4TyzHTaYWb1GX1qTfsHhEqV6HUDd_BzoBZnwfnvQc_1oF26ClkoUSEQ==',
-              },
-              request: {
-                clientIp: '203.0.113.178',
-                headers: {
-                  'x-forwarded-for': [
-                    {
-                      key: 'X-Forwarded-For',
-                      value: '203.0.113.178',
-                    },
-                  ],
-                  'user-agent': [
-                    {
-                      key: 'User-Agent',
-                      value: 'Amazon CloudFront',
-                    },
-                  ],
-                  via: [
-                    {
-                      key: 'Via',
-                      value:
-                        '2.0 2afae0d44e2540f472c0635ab62c232b.cloudfront.net (CloudFront)',
-                    },
-                  ],
-                  host: [
-                    {
-                      key: 'Host',
-                      value: 'example.org',
-                    },
-                  ],
-                  'cache-control': [
-                    {
-                      key: 'Cache-Control',
-                      value: 'no-cache, cf-no-cache',
-                    },
-                  ],
-                },
-                method: 'GET',
-                origin: {
-                  s3: {
-                    customHeaders: {
-                      'x-env-config-endpoint': [
-                        {
-                          key: 'x-env-config-endpoint',
-                          value: configEndpoint,
-                        },
-                      ],
-                      'x-env-api-endpoint': [
-                        {
-                          key: 'x-env-api-endpoint',
-                          value: 'example.localhost',
-                        },
-                      ],
-                    },
-                    region: 'us-east-1',
-                    authMethod: 'origin-access-identity',
-                    domainName: 's3.localhost',
-                    path: '',
-                  },
-                },
-                querystring: '',
-                uri: requestPath,
-              },
-            },
-          },
-        ],
-      };
-
-      const result = (await handler(event)) as CloudFrontRequest;
-
-      expect(result.origin?.s3).toEqual(
-        expect.objectContaining({
-          domainName: 's3.localhost',
-          path: '',
-        })
-      );
-      expect(result.uri).toBe('/index');
-    },
-    TIMEOUT
-  );
-
-  test(
-    'Add x-forwarded-host header to API-Gateway requests',
-    async () => {
-      const hostHeader = 'example.org';
-      const proxyConfig: ProxyConfig = {
-        lambdaRoutes: ['/__NEXT_API_LAMBDA_0'],
-        prerenders: {},
-        staticRoutes: [],
-        routes: [
-          {
-            src: '^(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/$',
-            headers: {
-              Location: '/$1',
-            },
-            status: 308,
-            continue: true,
-          },
-          {
-            src: '/404',
-            status: 404,
-            continue: true,
-          },
-          {
-            handle: 'filesystem',
-          },
-          {
-            src: '^/api/test/?$',
-            dest: '/__NEXT_API_LAMBDA_0',
-            headers: {
-              'x-nextjs-page': '/api/test',
-            },
-            check: true,
-          },
-          {
-            handle: 'resource',
-          },
-          {
-            src: '/.*',
-            status: 404,
-          },
-          {
-            handle: 'miss',
-          },
-          {
-            handle: 'rewrite',
-          },
-          {
-            src: '^/api/test/?$',
-            dest: '/__NEXT_API_LAMBDA_0',
-            headers: {
-              'x-nextjs-page': '/api/test',
-            },
-            check: true,
-          },
-          {
-            handle: 'hit',
-          },
-          {
-            handle: 'error',
-          },
-          {
-            src: '/.*',
-            dest: '/404',
-            status: 404,
-          },
-        ],
-      };
-      const requestPath = '/api/test';
-
-      // Prepare configServer
-      configServer.proxyConfig = proxyConfig;
-
-      // Origin Request
-      // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#example-origin-request
-      const event: CloudFrontRequestEvent = {
-        Records: [
-          {
-            cf: {
-              config: {
-                distributionDomainName: 'd111111abcdef8.cloudfront.net',
-                distributionId: 'EDFDVBD6EXAMPLE',
-                eventType: 'origin-request',
-                requestId:
-                  '4TyzHTaYWb1GX1qTfsHhEqV6HUDd_BzoBZnwfnvQc_1oF26ClkoUSEQ==',
-              },
-              request: {
-                clientIp: '203.0.113.178',
-                headers: {
-                  'x-forwarded-for': [
-                    {
-                      key: 'X-Forwarded-For',
-                      value: '203.0.113.178',
-                    },
-                  ],
-                  'user-agent': [
-                    {
-                      key: 'User-Agent',
-                      value: 'Amazon CloudFront',
-                    },
-                  ],
-                  via: [
-                    {
-                      key: 'Via',
-                      value:
-                        '2.0 2afae0d44e2540f472c0635ab62c232b.cloudfront.net (CloudFront)',
-                    },
-                  ],
-                  host: [
-                    {
-                      key: 'Host',
-                      value: hostHeader,
-                    },
-                  ],
-                  'cache-control': [
-                    {
-                      key: 'Cache-Control',
-                      value: 'no-cache, cf-no-cache',
-                    },
-                  ],
-                },
-                method: 'GET',
-                origin: {
-                  s3: {
-                    customHeaders: {
-                      'x-env-config-endpoint': [
-                        {
-                          key: 'x-env-config-endpoint',
-                          value: configEndpoint,
-                        },
-                      ],
-                      'x-env-api-endpoint': [
-                        {
-                          key: 'x-env-api-endpoint',
-                          value: 'api-gateway.local',
-                        },
-                      ],
-                    },
-                    region: 'us-east-1',
-                    authMethod: 'origin-access-identity',
-                    domainName: 's3.localhost',
-                    path: '',
-                  },
-                },
-                querystring: '',
-                uri: requestPath,
-              },
-            },
-          },
-        ],
-      };
-
-      const result = (await handler(event)) as CloudFrontRequest;
-
-      expect(result.origin?.custom).toEqual(
-        expect.objectContaining({
-          domainName: 'api-gateway.local',
-          path: '/__NEXT_API_LAMBDA_0',
-        })
-      );
-      expect(result.headers).toEqual(
-        expect.objectContaining({
-          'x-nextjs-page': [
-            {
-              key: 'x-nextjs-page',
-              value: '/api/test',
-            },
-          ],
-          'x-forwarded-host': [
-            {
-              key: 'X-Forwarded-Host',
-              value: hostHeader,
-            },
-          ],
-        })
-      );
-    },
-    TIMEOUT
-  );
+      })
+    );
+  });
 
   // Related to issue: https://github.com/milliHQ/terraform-aws-next-js/issues/218
-  test(
-    'Dynamic routes with dynamic part in directory',
-    async () => {
-      const proxyConfig: ProxyConfig = {
-        lambdaRoutes: ['/__NEXT_API_LAMBDA_0', '/__NEXT_PAGE_LAMBDA_0'],
-        prerenders: {},
-        staticRoutes: [
-          '/404',
-          '/500',
-          '/favicon.ico',
-          '/about',
-          '/users/[user_id]',
-        ],
-        routes: [
-          {
-            src: '^(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/$',
-            headers: {
-              Location: '/$1',
-            },
-            status: 308,
-            continue: true,
+  test('Dynamic routes with dynamic part in directory', async () => {
+    const proxyConfig: ProxyConfig = {
+      lambdaRoutes: ['/__NEXT_API_LAMBDA_0', '/__NEXT_PAGE_LAMBDA_0'],
+      prerenders: {},
+      staticRoutes: [
+        '/404',
+        '/500',
+        '/favicon.ico',
+        '/about',
+        '/users/[user_id]',
+      ],
+      routes: [
+        {
+          src: '^(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/$',
+          headers: {
+            Location: '/$1',
           },
-          {
-            src: '^\\/blog(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$',
-            headers: {
-              Location: '/test/$1',
-            },
-            status: 308,
+          status: 308,
+          continue: true,
+        },
+        {
+          src: '^\\/blog(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$',
+          headers: {
+            Location: '/test/$1',
           },
-          {
-            src: '/404',
-            status: 404,
-            continue: true,
+          status: 308,
+        },
+        {
+          src: '/404',
+          status: 404,
+          continue: true,
+        },
+        {
+          handle: 'filesystem',
+        },
+        {
+          src: '^/api/robots/?$',
+          dest: '/__NEXT_API_LAMBDA_0',
+          headers: {
+            'x-nextjs-page': '/api/robots',
           },
-          {
-            handle: 'filesystem',
+          check: true,
+        },
+        {
+          src: '^(/|/index|)/?$',
+          dest: '/__NEXT_PAGE_LAMBDA_0',
+          headers: {
+            'x-nextjs-page': '/index',
           },
-          {
-            src: '^/api/robots/?$',
-            dest: '/__NEXT_API_LAMBDA_0',
-            headers: {
-              'x-nextjs-page': '/api/robots',
-            },
-            check: true,
+          check: true,
+        },
+        {
+          src: '^\\/robots\\.txt$',
+          dest: '/api/robots',
+          check: true,
+        },
+        {
+          handle: 'resource',
+        },
+        {
+          src: '/.*',
+          status: 404,
+        },
+        {
+          handle: 'miss',
+        },
+        {
+          handle: 'rewrite',
+        },
+        {
+          src: '^/_next/data/oniBm2oZ9GXevuUEdEG44/index.json$',
+          dest: '/',
+          check: true,
+        },
+        {
+          src: '^/_next/data/oniBm2oZ9GXevuUEdEG44/test/(?<slug>.+?)\\.json$',
+          dest: '/test/[...slug]?slug=$slug',
+          check: true,
+        },
+        {
+          src: '^/test/\\[\\.\\.\\.slug\\]/?$',
+          dest: '/__NEXT_PAGE_LAMBDA_0',
+          headers: {
+            'x-nextjs-page': '/test/[...slug]',
           },
-          {
-            src: '^(/|/index|)/?$',
-            dest: '/__NEXT_PAGE_LAMBDA_0',
-            headers: {
-              'x-nextjs-page': '/index',
-            },
-            check: true,
+          check: true,
+        },
+        {
+          src: '^/api/robots/?$',
+          dest: '/__NEXT_API_LAMBDA_0',
+          headers: {
+            'x-nextjs-page': '/api/robots',
           },
-          {
-            src: '^\\/robots\\.txt$',
-            dest: '/api/robots',
-            check: true,
+          check: true,
+        },
+        {
+          src: '^(/|/index|)/?$',
+          dest: '/__NEXT_PAGE_LAMBDA_0',
+          headers: {
+            'x-nextjs-page': '/index',
           },
-          {
-            handle: 'resource',
+          check: true,
+        },
+        {
+          src: '^/test/(?<slug>.+?)(?:/)?$',
+          dest: '/test/[...slug]?slug=$slug',
+          check: true,
+        },
+        {
+          src: '^/test/\\[\\.\\.\\.slug\\]/?$',
+          dest: '/__NEXT_PAGE_LAMBDA_0',
+          headers: {
+            'x-nextjs-page': '/test/[...slug]',
           },
-          {
-            src: '/.*',
-            status: 404,
-          },
-          {
-            handle: 'miss',
-          },
-          {
-            handle: 'rewrite',
-          },
-          {
-            src: '^/_next/data/oniBm2oZ9GXevuUEdEG44/index.json$',
-            dest: '/',
-            check: true,
-          },
-          {
-            src: '^/_next/data/oniBm2oZ9GXevuUEdEG44/test/(?<slug>.+?)\\.json$',
-            dest: '/test/[...slug]?slug=$slug',
-            check: true,
-          },
-          {
-            src: '^/test/\\[\\.\\.\\.slug\\]/?$',
-            dest: '/__NEXT_PAGE_LAMBDA_0',
-            headers: {
-              'x-nextjs-page': '/test/[...slug]',
-            },
-            check: true,
-          },
-          {
-            src: '^/api/robots/?$',
-            dest: '/__NEXT_API_LAMBDA_0',
-            headers: {
-              'x-nextjs-page': '/api/robots',
-            },
-            check: true,
-          },
-          {
-            src: '^(/|/index|)/?$',
-            dest: '/__NEXT_PAGE_LAMBDA_0',
-            headers: {
-              'x-nextjs-page': '/index',
-            },
-            check: true,
-          },
-          {
-            src: '^/test/(?<slug>.+?)(?:/)?$',
-            dest: '/test/[...slug]?slug=$slug',
-            check: true,
-          },
-          {
-            src: '^/test/\\[\\.\\.\\.slug\\]/?$',
-            dest: '/__NEXT_PAGE_LAMBDA_0',
-            headers: {
-              'x-nextjs-page': '/test/[...slug]',
-            },
-            check: true,
-          },
-          {
-            src: '^/users/(?<user_id>[^/]+?)(?:/)?$',
-            dest: '/users/[user_id]?user_id=$user_id',
-            check: true,
-          },
-          {
-            handle: 'hit',
-          },
-          {
-            handle: 'error',
-          },
-          {
-            src: '/.*',
-            dest: '/404',
-            status: 404,
-          },
-        ],
-      };
-      const requestPath = '/users/432';
+          check: true,
+        },
+        {
+          src: '^/users/(?<user_id>[^/]+?)(?:/)?$',
+          dest: '/users/[user_id]?user_id=$user_id',
+          check: true,
+        },
+        {
+          handle: 'hit',
+        },
+        {
+          handle: 'error',
+        },
+        {
+          src: '/.*',
+          dest: '/404',
+          status: 404,
+        },
+      ],
+    };
+    const requestPath = '/users/432';
 
-      // Prepare configServer
-      configServer.proxyConfig = proxyConfig;
+    // Prepare configServer
+    configServer.proxyConfig = proxyConfig;
+    const cloudFrontEvent = generateCloudFrontRequestEvent({
+      configEndpoint,
+      uri: requestPath,
+    });
+    const result = (await handler(cloudFrontEvent)) as CloudFrontRequest;
 
-      // Origin Request
-      // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#example-origin-request
-      const event: CloudFrontRequestEvent = {
-        Records: [
-          {
-            cf: {
-              config: {
-                distributionDomainName: 'd111111abcdef8.cloudfront.net',
-                distributionId: 'EDFDVBD6EXAMPLE',
-                eventType: 'origin-request',
-                requestId:
-                  '4TyzHTaYWb1GX1qTfsHhEqV6HUDd_BzoBZnwfnvQc_1oF26ClkoUSEQ==',
-              },
-              request: {
-                clientIp: '203.0.113.178',
-                headers: {
-                  'x-forwarded-for': [
-                    {
-                      key: 'X-Forwarded-For',
-                      value: '203.0.113.178',
-                    },
-                  ],
-                  'user-agent': [
-                    {
-                      key: 'User-Agent',
-                      value: 'Amazon CloudFront',
-                    },
-                  ],
-                  via: [
-                    {
-                      key: 'Via',
-                      value:
-                        '2.0 2afae0d44e2540f472c0635ab62c232b.cloudfront.net (CloudFront)',
-                    },
-                  ],
-                  'cache-control': [
-                    {
-                      key: 'Cache-Control',
-                      value: 'no-cache, cf-no-cache',
-                    },
-                  ],
-                },
-                method: 'GET',
-                origin: {
-                  s3: {
-                    customHeaders: {
-                      'x-env-config-endpoint': [
-                        {
-                          key: 'x-env-config-endpoint',
-                          value: configEndpoint,
-                        },
-                      ],
-                      'x-env-api-endpoint': [
-                        {
-                          key: 'x-env-api-endpoint',
-                          value: 'api-gateway.local',
-                        },
-                      ],
-                    },
-                    region: 'us-east-1',
-                    authMethod: 'origin-access-identity',
-                    domainName: 's3.localhost',
-                    path: '',
-                  },
-                },
-                querystring: '',
-                uri: requestPath,
-              },
-            },
+    expect(result.origin?.s3).toEqual(
+      expect.objectContaining({
+        domainName: 's3.localhost',
+        path: '',
+      })
+    );
+    expect(result.uri).toBe('/users/[user_id]');
+  });
+
+  test('Redirects with querystring', async () => {
+    const proxyConfig: ProxyConfig = {
+      lambdaRoutes: [],
+      prerenders: {},
+      staticRoutes: [],
+      routes: [
+        {
+          src: '^(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/$',
+          headers: {
+            Location: '/$1',
           },
-        ],
-      };
+          status: 308,
+          continue: true,
+        },
+        {
+          src: '^\\/one$',
+          headers: {
+            Location: '/newplace',
+          },
+          status: 308,
+        },
+        {
+          src: '^\\/two(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))?$',
+          headers: {
+            Location: '/newplacetwo/$1',
+          },
+          status: 308,
+        },
+        {
+          src: '^\\/three$',
+          headers: {
+            Location: '/newplace?foo=bar',
+          },
+          status: 308,
+        },
+        {
+          src: '^\\/four$',
+          headers: {
+            Location: 'https://example.com',
+          },
+          status: 308,
+        },
+      ],
+    };
+    configServer.proxyConfig = proxyConfig;
 
-      const result = (await handler(event)) as CloudFrontRequest;
-
-      expect(result.origin?.s3).toEqual(
+    {
+      // Remove trailing slash
+      // /test/?foo=bar -> /test?foo=bar
+      const cloudFrontEvent = generateCloudFrontRequestEvent({
+        configEndpoint,
+        uri: '/test/',
+        querystring: 'foo=bar',
+      });
+      const result = (await handler(cloudFrontEvent)) as CloudFrontRequest;
+      expect(result.headers).toEqual(
         expect.objectContaining({
-          domainName: 's3.localhost',
-          path: '',
+          location: [
+            {
+              key: 'Location',
+              value: '/test?foo=bar',
+            },
+          ],
         })
       );
-      expect(result.uri).toBe('/users/[user_id]');
-    },
-    TIMEOUT
-  );
+    }
+
+    {
+      // Relative route replace
+      // /one?foo=bar -> /newplace?foo=bar
+      const cloudFrontEvent = generateCloudFrontRequestEvent({
+        configEndpoint,
+        uri: '/one',
+        querystring: 'foo=bar',
+      });
+      const result = (await handler(cloudFrontEvent)) as CloudFrontRequest;
+      expect(result.headers).toEqual(
+        expect.objectContaining({
+          location: [
+            {
+              key: 'Location',
+              value: '/newplace?foo=bar',
+            },
+          ],
+        })
+      );
+    }
+
+    {
+      // Relative route partial replace
+      // /two/some/path?foo=bar -> /newplace/some/path?foo=bar
+      const cloudFrontEvent = generateCloudFrontRequestEvent({
+        configEndpoint,
+        uri: '/two/some/path',
+        querystring: 'foo=bar',
+      });
+      const result = (await handler(cloudFrontEvent)) as CloudFrontRequest;
+      expect(result.headers).toEqual(
+        expect.objectContaining({
+          location: [
+            {
+              key: 'Location',
+              value: '/newplacetwo/some/path?foo=bar',
+            },
+          ],
+        })
+      );
+    }
+
+    {
+      // Try to override predefined param
+      // /three?foo=badValue -> /newplace?foo=bar
+      const cloudFrontEvent = generateCloudFrontRequestEvent({
+        configEndpoint,
+        uri: '/three',
+        querystring: 'foo=badValue',
+      });
+      const result = (await handler(cloudFrontEvent)) as CloudFrontRequest;
+      expect(result.headers).toEqual(
+        expect.objectContaining({
+          location: [
+            {
+              key: 'Location',
+              value: '/newplace?foo=bar',
+            },
+          ],
+        })
+      );
+    }
+
+    {
+      // Redirect to external URL
+      // /four?foo=bar -> https://example.com?foo=bar
+      const cloudFrontEvent = generateCloudFrontRequestEvent({
+        configEndpoint,
+        uri: '/four',
+        querystring: 'foo=bar',
+      });
+      const result = (await handler(cloudFrontEvent)) as CloudFrontRequest;
+      expect(result.headers).toEqual(
+        expect.objectContaining({
+          location: [
+            {
+              key: 'Location',
+              value: 'https://example.com/?foo=bar',
+            },
+          ],
+        })
+      );
+    }
+  });
 });

--- a/packages/proxy/test/proxy.unit.test.ts
+++ b/packages/proxy/test/proxy.unit.test.ts
@@ -3,12 +3,13 @@
  * @see: https://github.com/vercel/vercel/blob/master/packages/now-cli/test/dev-router.unit.js
  */
 
-import { Route } from '@vercel/routing-utils';
 import { URLSearchParams } from 'url';
+
+import { Route } from '@vercel/routing-utils';
 
 import { Proxy } from '../src/proxy';
 
-test('[proxy-unit] captured groups', () => {
+test('Captured groups', () => {
   const routesConfig = [{ src: '/api/(.*)', dest: '/endpoints/$1.js' }];
   const result = new Proxy(routesConfig, [], []).route('/api/user');
 
@@ -27,7 +28,7 @@ test('[proxy-unit] captured groups', () => {
   });
 });
 
-test('[proxy-unit] named groups', () => {
+test('Named groups', () => {
   const routesConfig = [{ src: '/user/(?<id>.+)', dest: '/user.js?id=$id' }];
   const result = new Proxy(routesConfig, [], []).route('/user/123');
 
@@ -46,7 +47,7 @@ test('[proxy-unit] named groups', () => {
   });
 });
 
-test('[proxy-unit] optional named groups', () => {
+test('Optional named groups', () => {
   const routesConfig = [
     {
       src: '/api/hello(/(?<name>[^/]+))?',
@@ -70,7 +71,7 @@ test('[proxy-unit] optional named groups', () => {
   });
 });
 
-test('[proxy-unit] shared lambda', () => {
+test('Shared lambda', () => {
   const routesConfig = [
     {
       src: '^/product/\\[\\.\\.\\.slug\\]/?$',
@@ -101,7 +102,7 @@ test('[proxy-unit] shared lambda', () => {
   });
 });
 
-test('[proxy-unit] slug group and shared lambda', () => {
+test('Slug group and shared lambda', () => {
   const routesConfig = [
     {
       src: '^/product/(?<slug>.+?)(?:/)?$',
@@ -137,7 +138,7 @@ test('[proxy-unit] slug group and shared lambda', () => {
   });
 });
 
-test('[proxy-unit] Ignore other routes when no continue is set', () => {
+test('Ignore other routes when no continue is set', () => {
   const routesConfig = [
     { src: '/about', dest: '/about.html' },
     { src: '/about', dest: '/about.php' },
@@ -160,7 +161,7 @@ test('[proxy-unit] Ignore other routes when no continue is set', () => {
   });
 });
 
-test('[proxy-unit] Continue after first route found', () => {
+test('Continue after first route found', () => {
   const routesConfig = [
     {
       src: '/about',
@@ -192,7 +193,7 @@ test('[proxy-unit] Continue after first route found', () => {
   });
 });
 
-test('[proxy-unit] Redirect: Remove trailing slash', () => {
+test('Redirect: Remove trailing slash', () => {
   const routesConfig: Route[] = [
     {
       src: '^(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/$',
@@ -237,7 +238,7 @@ test('[proxy-unit] Redirect: Remove trailing slash', () => {
   });
 });
 
-test('[proxy-unit] With trailing slash', () => {
+test('With trailing slash', () => {
   const routesConfig: Route[] = [
     {
       handle: 'filesystem',
@@ -270,7 +271,7 @@ test('[proxy-unit] With trailing slash', () => {
   });
 });
 
-test('[proxy-unit] Redirect partial replace', () => {
+test('Redirect partial replace', () => {
   const routesConfig = [
     {
       src: '^\\/redir(?:\\/([^\\/]+?))$',
@@ -307,7 +308,7 @@ test('[proxy-unit] Redirect partial replace', () => {
   });
 });
 
-test('[proxy-unit] External rewrite', () => {
+test('External rewrite', () => {
   const routesConfig = [
     {
       src: '^\\/docs(?:\\/([^\\/]+?))$',
@@ -334,7 +335,7 @@ test('[proxy-unit] External rewrite', () => {
   });
 });
 
-test('[proxy-unit] Rewrite with ^ and $', () => {
+test('Rewrite with ^ and $', () => {
   const routesConfig = [
     {
       src: '^/$',
@@ -361,7 +362,7 @@ test('[proxy-unit] Rewrite with ^ and $', () => {
   });
 });
 
-test('[proxy-unit] i18n default locale', () => {
+test('I18n default locale', () => {
   const routesConfig = [
     {
       src: '^/(?!(?:_next/.*|en|fr\\-FR|nl)(?:/.*|$))(.*)$',
@@ -405,7 +406,7 @@ test('[proxy-unit] i18n default locale', () => {
   });
 });
 
-test('[proxy-unit] static index route', () => {
+test('Static index route', () => {
   const routesConfig = [
     {
       handle: 'filesystem' as const,
@@ -425,7 +426,7 @@ test('[proxy-unit] static index route', () => {
   });
 });
 
-test('[proxy-unit] multiple dynamic parts', () => {
+test('Multiple dynamic parts', () => {
   const routesConfig: Route[] = [
     {
       handle: 'filesystem',
@@ -462,7 +463,7 @@ test('[proxy-unit] multiple dynamic parts', () => {
   });
 });
 
-test('[proxy-unit] Dynamic static route', () => {
+test('Dynamic static route', () => {
   const routesConfig: Route[] = [
     {
       handle: 'rewrite',

--- a/packages/proxy/test/resolve-route-parameters.test.ts
+++ b/packages/proxy/test/resolve-route-parameters.test.ts
@@ -34,4 +34,18 @@ describe('resolve route parameters', () => {
 
     expect(result).toBe('/users/[user_id]?user_id=123');
   });
+
+  test('Append existing querystring', () => {
+    const matcher = new RegExp(
+      '^(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/$',
+      'i'
+    );
+    const match = matcher.exec('/test/');
+
+    expect(match).not.toBeNull();
+    const keys = Object.keys(match!.groups ?? { foo: 'bar' });
+    const result = resolveRouteParameters('/$1', match!, keys);
+
+    expect(result).toBe('/test?foo=bar');
+  });
 });

--- a/packages/proxy/test/resolve-route-parameters.test.ts
+++ b/packages/proxy/test/resolve-route-parameters.test.ts
@@ -34,18 +34,4 @@ describe('resolve route parameters', () => {
 
     expect(result).toBe('/users/[user_id]?user_id=123');
   });
-
-  test('Append existing querystring', () => {
-    const matcher = new RegExp(
-      '^(?:\\/((?:[^\\/]+?)(?:\\/(?:[^\\/]+?))*))\\/$',
-      'i'
-    );
-    const match = matcher.exec('/test/');
-
-    expect(match).not.toBeNull();
-    const keys = Object.keys(match!.groups ?? { foo: 'bar' });
-    const result = resolveRouteParameters('/$1', match!, keys);
-
-    expect(result).toBe('/test?foo=bar');
-  });
 });

--- a/packages/proxy/test/test-utils.ts
+++ b/packages/proxy/test/test-utils.ts
@@ -2,6 +2,10 @@ import { CloudFrontRequestEvent } from 'aws-lambda';
 
 type GenerateCloudFrontRequestEventOptions = {
   /**
+   * Endpoint of the API Gateway.
+   */
+  apiGatewayEndpoint?: string;
+  /**
    * URL where the proxy config can be fetched from.
    */
   configEndpoint: string;
@@ -22,7 +26,12 @@ type GenerateCloudFrontRequestEventOptions = {
 function generateCloudFrontRequestEvent(
   options: GenerateCloudFrontRequestEventOptions
 ): CloudFrontRequestEvent {
-  const { configEndpoint, querystring = '', uri } = options;
+  const {
+    apiGatewayEndpoint = 'example.localhost',
+    configEndpoint,
+    querystring = '',
+    uri,
+  } = options;
 
   return {
     Records: [
@@ -83,7 +92,7 @@ function generateCloudFrontRequestEvent(
                   'x-env-api-endpoint': [
                     {
                       key: 'x-env-api-endpoint',
-                      value: 'example.localhost',
+                      value: apiGatewayEndpoint,
                     },
                   ],
                 },

--- a/packages/proxy/test/test-utils.ts
+++ b/packages/proxy/test/test-utils.ts
@@ -1,0 +1,105 @@
+import { CloudFrontRequestEvent } from 'aws-lambda';
+
+type GenerateCloudFrontRequestEventOptions = {
+  /**
+   * URL where the proxy config can be fetched from.
+   */
+  configEndpoint: string;
+  /**
+   * Querystring of the original request.
+   */
+  querystring?: string;
+  /**
+   * Pathname (without querystring) of the original request.
+   */
+  uri: string;
+};
+
+/**
+ * Generates a CloudFrontRequestEvent object.
+ * @see {@link https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-event-structure.html#example-origin-request}
+ */
+function generateCloudFrontRequestEvent(
+  options: GenerateCloudFrontRequestEventOptions
+): CloudFrontRequestEvent {
+  const { configEndpoint, querystring = '', uri } = options;
+
+  return {
+    Records: [
+      {
+        cf: {
+          config: {
+            distributionDomainName: 'd111111abcdef8.cloudfront.net',
+            distributionId: 'EDFDVBD6EXAMPLE',
+            eventType: 'origin-request',
+            requestId:
+              '4TyzHTaYWb1GX1qTfsHhEqV6HUDd_BzoBZnwfnvQc_1oF26ClkoUSEQ==',
+          },
+          request: {
+            clientIp: '203.0.113.178',
+            headers: {
+              'x-forwarded-for': [
+                {
+                  key: 'X-Forwarded-For',
+                  value: '203.0.113.178',
+                },
+              ],
+              'user-agent': [
+                {
+                  key: 'User-Agent',
+                  value: 'Amazon CloudFront',
+                },
+              ],
+              via: [
+                {
+                  key: 'Via',
+                  value:
+                    '2.0 2afae0d44e2540f472c0635ab62c232b.cloudfront.net (CloudFront)',
+                },
+              ],
+              host: [
+                {
+                  key: 'Host',
+                  value: 'example.org',
+                },
+              ],
+              'cache-control': [
+                {
+                  key: 'Cache-Control',
+                  value: 'no-cache, cf-no-cache',
+                },
+              ],
+            },
+            method: 'GET',
+            origin: {
+              s3: {
+                customHeaders: {
+                  'x-env-config-endpoint': [
+                    {
+                      key: 'x-env-config-endpoint',
+                      value: configEndpoint,
+                    },
+                  ],
+                  'x-env-api-endpoint': [
+                    {
+                      key: 'x-env-api-endpoint',
+                      value: 'example.localhost',
+                    },
+                  ],
+                },
+                region: 'us-east-1',
+                authMethod: 'origin-access-identity',
+                domainName: 's3.localhost',
+                path: '',
+              },
+            },
+            querystring,
+            uri,
+          },
+        },
+      },
+    ],
+  };
+}
+
+export { generateCloudFrontRequestEvent };

--- a/packages/proxy/test/util/append-querystring.test.ts
+++ b/packages/proxy/test/util/append-querystring.test.ts
@@ -1,0 +1,94 @@
+import { URLSearchParams } from 'url';
+
+import { appendQuerystring } from '../../src/util/append-querystring';
+
+describe('Relative URL', () => {
+  test('SearchParams', () => {
+    const result = appendQuerystring('/test', new URLSearchParams('foo=bar'));
+    expect(result).toBe('/test?foo=bar');
+  });
+
+  test('Empty SearchParams', () => {
+    const result = appendQuerystring('/test', new URLSearchParams());
+    expect(result).toBe('/test');
+  });
+
+  test('Querystring, empty SearchParams', () => {
+    const result = appendQuerystring('/test?foo=bar', new URLSearchParams());
+    expect(result).toBe('/test?foo=bar');
+  });
+
+  test('Querystring, same SearchParams', () => {
+    const result = appendQuerystring(
+      '/test?foo=bar',
+      new URLSearchParams('foo=bar')
+    );
+    expect(result).toBe('/test?foo=bar');
+  });
+
+  test('Querystring, different SearchParams', () => {
+    const result = appendQuerystring(
+      '/test?foo=bar',
+      new URLSearchParams('bar=foo')
+    );
+    expect(result).toBe('/test?bar=foo&foo=bar');
+  });
+
+  test('Querystring, try to override SearchParams', () => {
+    const result = appendQuerystring(
+      '/test?foo=bar',
+      new URLSearchParams('foo=xxx')
+    );
+    expect(result).toBe('/test?foo=bar');
+  });
+});
+
+describe('Absolute URL', () => {
+  test('SearchParams', () => {
+    const result = appendQuerystring(
+      'https://example.org/test',
+      new URLSearchParams('foo=bar')
+    );
+    expect(result).toBe('https://example.org/test?foo=bar');
+  });
+
+  test('Empty SearchParams', () => {
+    const result = appendQuerystring(
+      'https://example.org/test',
+      new URLSearchParams()
+    );
+    expect(result).toBe('https://example.org/test');
+  });
+
+  test('Querystring, empty SearchParams', () => {
+    const result = appendQuerystring(
+      'https://example.org/test?foo=bar',
+      new URLSearchParams()
+    );
+    expect(result).toBe('https://example.org/test?foo=bar');
+  });
+
+  test('Querystring, same SearchParams', () => {
+    const result = appendQuerystring(
+      'https://example.org/test?foo=bar',
+      new URLSearchParams('foo=bar')
+    );
+    expect(result).toBe('https://example.org/test?foo=bar');
+  });
+
+  test('Querystring, different SearchParams', () => {
+    const result = appendQuerystring(
+      'https://example.org/test?foo=bar',
+      new URLSearchParams('bar=foo')
+    );
+    expect(result).toBe('https://example.org/test?bar=foo&foo=bar');
+  });
+
+  test('Querystring, try to override SearchParams', () => {
+    const result = appendQuerystring(
+      'https://example.org/test?foo=bar',
+      new URLSearchParams('foo=xxx')
+    );
+    expect(result).toBe('https://example.org/test?foo=bar');
+  });
+});


### PR DESCRIPTION
## Changes
- Appends the original querystring to redirects
- Cache-Control header is set to `public, max-age=0, must-revalidate` for redirect responses
- Content-Type for redirects is now `text/plain`
- Adds response body to redirects, e.g. `Redirecting to /newplacetwo/some/path?foo=xxx (308)`

Fixes #296.