### PR TITLE
Add support for nodejs16.x runtime

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,9 +13,12 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: registry.gitlab.com/dealmore/dealmore-build-images/lambda:nodejs14.x
+    container: public.ecr.aws/sam/build-nodejs16.x:latest
 
     steps:
+      - name: Install yarn
+        run: npm install --global yarn@1.22.18
+
       - uses: actions/checkout@v2
 
       - name: Cache
@@ -48,7 +51,7 @@ jobs:
   test-integration:
     needs: build
     runs-on: ubuntu-latest
-    container: registry.gitlab.com/dealmore/dealmore-build-images/lambda:nodejs14.x
+    container: public.ecr.aws/sam/build-nodejs16.x:latest
     services:
       s3:
         image: registry.gitlab.com/dealmore/dealmore-build-images:s3-emulator
@@ -62,6 +65,9 @@ jobs:
       S3_ENDPOINT: s3:9000
 
     steps:
+      - name: Install yarn
+        run: npm install --global yarn@1.22.18
+
       - uses: actions/checkout@v2
 
       - name: Cache
@@ -87,8 +93,11 @@ jobs:
   test-e2e-prepare:
     needs: build
     runs-on: ubuntu-latest
-    container: registry.gitlab.com/dealmore/dealmore-build-images/lambda:nodejs14.x
+    container: public.ecr.aws/sam/build-nodejs16.x:latest
     steps:
+      - name: Install yarn
+        run: npm install --global yarn@1.22.18
+
       - uses: actions/checkout@v2
 
       - name: Cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - v[0-9]+.[0-9x]+.x
+      - v[0-9]+.[0-9x]
   pull_request:
 
 jobs:

--- a/.github/workflows/tf-docs.yml
+++ b/.github/workflows/tf-docs.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - main
-      - v[0-9]+.[0-9x]+.x
+      - v[0-9]+.[0-9x]
 
 jobs:
   update-docs:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "release:ci": "release-it --no-increment --no-git.push --ci"
   },
   "devDependencies": {
-    "@millihq/sammy": "^2.0.1",
+    "@millihq/sammy": "^3.0.0",
     "@release-it/bumper": "^3.0.1",
     "@ofhouse/keep-a-changelog": "2.3.0-no-increment-fix",
     "@tsconfig/node14": "^1.0.1",
@@ -39,7 +39,7 @@
   },
   "resolutions": {
     "archiver": "^5.3.0",
-    "aws-sdk": "2.1001.0"
+    "aws-sdk": "2.1055.0"
   },
   "release-it": {
     "git": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -26,7 +26,7 @@
     "@types/resolve-from": "5.0.1",
     "@types/semver": "6.0.0",
     "@types/yazl": "2.4.1",
-    "@vercel/build-utils": "2.12.1",
+    "@vercel/build-utils": "2.17.0",
     "@vercel/nft": "0.10.0",
     "@vercel/routing-utils": "1.10.1",
     "async-sema": "3.0.1",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -5,6 +5,7 @@ import {
   FileFsRef,
   Files,
   Lambda,
+  Meta,
   NowBuildError,
   PackageJson,
   PrepareCacheOptions,
@@ -72,17 +73,11 @@ const {
   getNodeBinPath,
 } = buildUtils;
 
-interface BuildParamsMeta {
-  isDev: boolean | undefined;
-  env?: EnvConfig;
-  buildEnv?: EnvConfig;
-}
-
 interface BuildParamsType extends BuildOptions {
   files: Files;
   entrypoint: string;
   workPath: string;
-  meta: BuildParamsMeta;
+  meta: Meta;
 }
 
 export const version = 2;
@@ -220,7 +215,7 @@ export async function build({
   repoRootPath,
   entrypoint,
   config = {} as Config,
-  meta = {} as BuildParamsMeta,
+  meta = {} as Meta,
 }: BuildParamsType): Promise<{
   routes: Route[];
   images?: {

--- a/packages/tf-next/package.json
+++ b/packages/tf-next/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@millihq/tf-next-runtime": "0.12.2",
-    "@vercel/build-utils": "2.12.1",
+    "@vercel/build-utils": "2.17.0",
     "@vercel/frameworks": "^0.0.15",
     "@vercel/routing-utils": "^1.10.1",
     "archiver": "^5.3.0",

--- a/packages/tf-next/src/commands/build.ts
+++ b/packages/tf-next/src/commands/build.ts
@@ -115,7 +115,7 @@ function writeOutput(props: OutputProps) {
 
     config.lambdas[key] = {
       handler: lambda.handler,
-      runtime: lambda.runtime as 'nodejs12.x' | 'nodejs14.x',
+      runtime: lambda.runtime as 'nodejs12.x' | 'nodejs14.x' | 'nodejs16.x',
       filename: path.relative(props.outputDir, zipFilename),
       route: normalizeRoute(route),
     };
@@ -223,10 +223,12 @@ async function buildCommand({
 
     for (const [key, file] of Object.entries(buildResult.output)) {
       switch (file.type) {
+        // @ts-ignore
         case 'Lambda': {
           lambdas[key] = (file as unknown) as Lambda;
           break;
         }
+        // @ts-ignore
         case 'Prerender': {
           prerenders[key] = (file as unknown) as Prerender;
           break;

--- a/packages/tf-next/src/types.ts
+++ b/packages/tf-next/src/types.ts
@@ -9,7 +9,7 @@ export interface ConfigOutput {
     string,
     {
       handler: string;
-      runtime: 'nodejs12.x' | 'nodejs14.x';
+      runtime: 'nodejs12.x' | 'nodejs14.x' | 'nodejs16.x';
       filename: string;
       route: string;
     }

--- a/variables.tf
+++ b/variables.tf
@@ -43,7 +43,7 @@ variable "lambda_environment_variables" {
 variable "lambda_runtime" {
   description = "Lambda Function runtime"
   type        = string
-  default     = "nodejs14.x"
+  default     = "nodejs16.x"
 }
 
 variable "lambda_memory_size" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 4.8"
+      version               = ">= 4.15.0"
       configuration_aliases = [aws.global_region]
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -792,15 +792,15 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@millihq/sammy@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@millihq/sammy/-/sammy-2.0.1.tgz#3200fbdb58449fd50d5df394dd9f21741650af77"
-  integrity sha512-6j76MsB5cKWJrlRD4D2bGeI74N1IzeM5PJS4HJWHkZmnhVgkbMxuDOazyS+A0ps8+m8HQ+Wa3n8li5iVGcbjNQ==
+"@millihq/sammy@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@millihq/sammy/-/sammy-3.0.0.tgz#23030fc8168b440781af82777fd3a982993a87cf"
+  integrity sha512-uYq80ADPvkritON12svv9lIFjaKMH59yyYcdAYIvdQNHjMuH8VY/aGAVKoq3eJrjyG6bm1Ngq+K10CIWLlMHbQ==
   dependencies:
-    aws-sdk "^2.804.0"
+    aws-sdk "^2.1055.0"
     change-case "^4.1.2"
     get-port "^5.1.1"
-    node-fetch "^2.6.1"
+    node-fetch "^2.6.7"
     tmp "^0.2.1"
     unzipper "^0.10.11"
     yaml "^1.10.0"
@@ -1352,10 +1352,10 @@
   dependencies:
     "@types/node" "*"
 
-"@vercel/build-utils@2.12.1":
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/@vercel/build-utils/-/build-utils-2.12.1.tgz#479a7eb0111985ff437d77dd395bb9ba6d108c95"
-  integrity sha512-85FUGmNQWL+gWORGIfW2amNeDt3vBgliZ51j3D9s+2qcAv+Li+ghLfzjoP5w5E+DhO8OxHfy53WbqR5aprAWEA==
+"@vercel/build-utils@2.17.0":
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/@vercel/build-utils/-/build-utils-2.17.0.tgz#18a24eeaf765fc97c7aed822a6ad83fa825f4c50"
+  integrity sha512-eKHx3nW5MJ21xQC9RQrm+OthmHiV0PHr6bRpJAhsXryE/H6fbNqr1ZxOAQJpq2MaoKzEA/6Lt7J4TjJLd4pkqA==
 
 "@vercel/frameworks@^0.0.15":
   version "0.0.15"
@@ -1650,10 +1650,10 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-aws-sdk@*, aws-sdk@2.1001.0, aws-sdk@^2.804.0:
-  version "2.1001.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1001.0.tgz#c4da256aa0058438ba611ae06fa850f4f7d63abc"
-  integrity sha512-DpmslPU8myCaaRUwMzB/SqAMtD2zQckxYwq3CguIv8BI+JHxDLeTdPCLfA5jffQ8k6dcvISOuiqdpwCZucU0BA==
+aws-sdk@*, aws-sdk@2.1055.0, aws-sdk@^2.1055.0:
+  version "2.1055.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1055.0.tgz#07beb86650d5a313f7c899807c51b12b5e2f4117"
+  integrity sha512-99drH3mvXakw9we8Rs2cDQmi2pS7PVAC9pvTlB7lHPUwLYftMlko5cFMceZxvTHeyLkdvg98iNIHI3hbnzitoQ==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
- Adds support for `nodejs16.x` runtime
- Increases minimum Terraform AWS provider version from `4.8` to `4.15.0`

Fixes #316.
Fixes #315.