### PR TITLE
Adds static prefix to files served from S3

### DIFF
--- a/packages/deploy-trigger/src/deploy-trigger.ts
+++ b/packages/deploy-trigger/src/deploy-trigger.ts
@@ -88,7 +88,16 @@ async function deployTrigger({
    * |   └── prerendered-site
    * └── config.json
    *
-   * And uploads it to the bucket in the following way
+   * And uploads it to the bucket in the following way:
+   *
+   * <deployment-id>/
+   * ├── lambdas/
+   * |   ├── lambda1.zip
+   * |   └── lambda2.zip
+   * ├── static/
+   * |   ├── _next/...
+   * |   └── prerendered-site
+   * └── manifest.json (contains the inventory of the `<deployment-id>/` path)
    */
   for await (const e of zip) {
     const entry = e as unzipper.Entry;
@@ -106,7 +115,7 @@ async function deployTrigger({
         continue;
       } else if (filePath.startsWith('lambdas')) {
         contentType = 'application/zip';
-        targetKey = `${deploymentId}/_tf_next/${filePath}`;
+        targetKey = `${deploymentId}/lambdas/${filePath}`;
 
         lambdaUploads.push(
           s3
@@ -120,7 +129,7 @@ async function deployTrigger({
         );
       } else {
         const filePathWithoutPrefix = filePath.substring('static/'.length);
-        targetKey = `${deploymentId}/${filePathWithoutPrefix}`;
+        targetKey = `${deploymentId}/static/${filePathWithoutPrefix}`;
 
         // Get ContentType
         // Static pre-rendered pages have no file extension,

--- a/packages/deploy-trigger/test/deploy-trigger.test.ts
+++ b/packages/deploy-trigger/test/deploy-trigger.test.ts
@@ -102,7 +102,7 @@ describe('deploy-trigger', () => {
         expect(Contents).toEqual(
           expect.arrayContaining([
             expect.objectContaining({
-              Key: `${deploymentId}/${fileKey}`,
+              Key: `${deploymentId}/static/${fileKey}`,
             }),
           ])
         );
@@ -112,7 +112,7 @@ describe('deploy-trigger', () => {
       const localeStaticRouteObject = await s3
         .getObject({
           Bucket: targetBucket.bucketName,
-          Key: `${deploymentId}/${localeStaticRouteKey}`,
+          Key: `${deploymentId}/static/${localeStaticRouteKey}`,
         })
         .promise();
 
@@ -127,7 +127,7 @@ describe('deploy-trigger', () => {
       const staticRouteObject = await s3
         .getObject({
           Bucket: targetBucket.bucketName,
-          Key: `${deploymentId}/${staticRouteKey}`,
+          Key: `${deploymentId}/static/${staticRouteKey}`,
         })
         .promise();
 
@@ -139,7 +139,7 @@ describe('deploy-trigger', () => {
       const staticAssetObject = await s3
         .getObject({
           Bucket: targetBucket.bucketName,
-          Key: `${deploymentId}/${staticAssetKey}`,
+          Key: `${deploymentId}/static/${staticAssetKey}`,
         })
         .promise();
       expect(staticAssetObject.ContentType).toBe(

--- a/packages/proxy-config/src/actions/deployment-file-exists.ts
+++ b/packages/proxy-config/src/actions/deployment-file-exists.ts
@@ -36,7 +36,7 @@ async function deploymentFileExists({
     const result = await s3Client
       .headObject({
         Bucket: s3BucketId,
-        Key: deploymentId + '/' + decodedKey,
+        Key: deploymentId + '/static/' + decodedKey,
       })
       .promise();
 

--- a/packages/proxy/src/util/custom-origin.ts
+++ b/packages/proxy/src/util/custom-origin.ts
@@ -141,7 +141,7 @@ function serveRequestFromS3Origin(
   });
 
   if (typeof uri === 'string') {
-    request.uri = `/${deploymentId}${uri}`;
+    request.uri = `/${deploymentId}/static${uri}`;
   }
 
   // Querystring is not supported by S3 origin

--- a/packages/proxy/test/handler.test.ts
+++ b/packages/proxy/test/handler.test.ts
@@ -302,7 +302,7 @@ describe('[proxy] Handler', () => {
       })
     );
     // deploymentId + path
-    expect(result.uri).toBe('/abc/en');
+    expect(result.uri).toBe('/abc/static/en');
   });
 
   test('Correctly request /index object from S3 when requesting /', async () => {
@@ -372,7 +372,7 @@ describe('[proxy] Handler', () => {
         path: '',
       })
     );
-    expect(result.uri).toBe('/abc/index');
+    expect(result.uri).toBe('/abc/static/index');
   });
 
   test('Add x-forwarded-host header to API-Gateway requests', async () => {
@@ -636,7 +636,7 @@ describe('[proxy] Handler', () => {
         path: '',
       })
     );
-    expect(result.uri).toBe('/abc/users/[user_id]');
+    expect(result.uri).toBe('/abc/static/users/[user_id]');
   });
 
   test('Redirects with querystring', async () => {


### PR DESCRIPTION
Adds a `static/` prefix to files served from S3.
Prevents that the lambda code can be downloaded by guessing the path.