### PR TITLE
Use CloudFormation role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -150,6 +150,7 @@ data "aws_iam_policy_document" "cloudformation_permission" {
       "iam:DeleteRolePolicy",
       "iam:UntagRole",
       "lambda:DeleteFunction",
+      "lambda:DeleteFunctionUrlConfig",
       "lambda:RemovePermission",
       "lambda:UntagResource",
       "logs:DeleteLogGroup",

--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,8 @@ resource "aws_dynamodb_table" "deployments" {
     projection_type    = "INCLUDE"
     non_key_attributes = ["CreateDate", "DeploymentAlias", "DeploymentId", "Status"]
   }
+
+  tags = var.tags
 }
 
 ###################

--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,108 @@ resource "aws_dynamodb_table" "deployments" {
   tags = var.tags
 }
 
+#####################
+# CloudFormation Role
+#####################
+
+# Policy that controls which actions can be performed when CloudFormation
+# creates a substack (from CDK)
+data "aws_iam_policy_document" "cloudformation_permission" {
+  # Allow CloudFormation to publish status changes to the SNS queue
+  statement {
+    effect = "Allow"
+    actions = [
+      "sns:Publish"
+    ]
+    resources = [module.deploy_controller.sns_topic_arn]
+  }
+
+  # Allow CloudFormation to access the lambda content
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject"
+    ]
+    resources = [
+      module.statics_deploy.static_bucket_arn,
+      "${module.statics_deploy.static_bucket_arn}/*"
+    ]
+  }
+
+  # Stack creation
+  statement {
+    effect = "Allow"
+    actions = [
+      # TODO: Restrict the API Gateway action more
+      "apigateway:*",
+      "iam:CreateRole",
+      "iam:GetRole",
+      "iam:GetRolePolicy",
+      "iam:PassRole",
+      "iam:PutRolePolicy",
+      "iam:TagRole",
+      "lambda:AddPermission",
+      "lambda:CreateFunction",
+      "lambda:CreateFunctionUrlConfig",
+      "lambda:GetFunctionUrlConfig",
+      "lambda:GetFunction",
+      "lambda:TagResource",
+      "logs:CreateLogGroup",
+      "logs:PutRetentionPolicy",
+      "logs:TagLogGroup"
+    ]
+    resources = ["*"]
+  }
+
+  # Stack deletion
+  statement {
+    effect = "Allow"
+    actions = [
+      "apigateway:*",
+      "iam:DeleteRole",
+      "iam:DeleteRolePolicy",
+      "iam:UntagRole",
+      "lambda:DeleteFunction",
+      "lambda:RemovePermission",
+      "lambda:UntagResource",
+      "logs:DeleteLogGroup",
+      "logs:DeleteRetentionPolicy",
+      "logs:UntagLogGroup"
+    ]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "cloudformation_permission_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudformation.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "cloudformation_permission" {
+  name        = "cloudformation-control"
+  path        = "/${var.deployment_name}/"
+  description = "Managed by Terraform Next.js"
+  policy      = data.aws_iam_policy_document.cloudformation_permission.json
+
+  tags = var.tags
+}
+
+resource "aws_iam_role" "cloudformation_permission" {
+  name               = "cloudformation-control"
+  path               = "/${var.deployment_name}/"
+  assume_role_policy = data.aws_iam_policy_document.cloudformation_permission_assume_role.json
+  managed_policy_arns = [
+    aws_iam_policy.cloudformation_permission.arn
+  ]
+}
+
 ###################
 # Deploy Controller
 ###################
@@ -126,6 +228,8 @@ module "statics_deploy" {
   dynamodb_region                 = data.aws_region.current.name
   dynamodb_table_deployments_arn  = aws_dynamodb_table.deployments.arn
   dynamodb_table_deployments_name = aws_dynamodb_table.deployments.id
+
+  cloudformation_role_arn = aws_iam_role.cloudformation_permission.arn
 
   lambda_role_permissions_boundary = var.lambda_role_permissions_boundary
 

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -35,6 +35,19 @@ data "aws_iam_policy_document" "access_upload_bucket" {
   }
 }
 
+# Initiate deletion of CloudFormation stacks
+data "aws_iam_policy_document" "delete_cloudformation_stack" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "cloudformation:DeleteStack"
+    ]
+    resources = [
+      "arn:aws:cloudformation:*:*:stack/*/*"
+    ]
+  }
+}
+
 module "lambda" {
   source = "../lambda-worker"
 
@@ -49,10 +62,11 @@ module "lambda" {
   memory_size   = 128
 
   attach_policy_jsons    = true
-  number_of_policy_jsons = 2
+  number_of_policy_jsons = 3
   policy_jsons = [
     data.aws_iam_policy_document.access_dynamodb_tables.json,
     data.aws_iam_policy_document.access_upload_bucket.json,
+    data.aws_iam_policy_document.delete_cloudformation_stack.json,
   ]
 
   environment_variables = {

--- a/modules/deploy-controller/main.tf
+++ b/modules/deploy-controller/main.tf
@@ -36,7 +36,8 @@ data "aws_iam_policy_document" "access_dynamodb_tables" {
       "dynamodb:GetItem",
       "dynamodb:PutItem",
       "dynamodb:Query",
-      "dynamodb:UpdateItem"
+      "dynamodb:UpdateItem",
+      "dynamodb:DeleteItem"
     ]
     resources = [
       var.dynamodb_table_deployments_arn,

--- a/modules/statics-deploy/main.tf
+++ b/modules/statics-deploy/main.tf
@@ -112,46 +112,20 @@ data "aws_iam_policy_document" "access_static_deploy" {
     resources = [var.cloudfront_arn]
   }
 
-  # Permissions for CloudFormation to create resources
+  # Create new substacks from CDK templates
   statement {
     actions = [
-      "apigateway:*",
-      "cloudformation:CreateStack",
-      "iam:CreateRole",
-      "iam:DeleteRole",
-      "iam:DeleteRolePolicy",
-      "iam:GetRole",
-      "iam:GetRolePolicy",
-      "iam:PassRole",
-      "iam:PutRolePolicy",
-      "iam:TagRole",
-      "iam:UntagRole",
-      "lambda:AddPermission",
-      "lambda:CreateFunction",
-      "lambda:DeleteFunction",
-      "lambda:CreateFunctionUrlConfig",
-      "lambda:GetFunctionUrlConfig",
-      "lambda:GetFunction",
-      "lambda:RemovePermission",
-      "lambda:TagResource",
-      "lambda:UntagResource",
-      "logs:CreateLogGroup",
-      "logs:DeleteLogGroup",
-      "logs:DeleteRetentionPolicy",
-      "logs:PutRetentionPolicy",
-      "logs:TagLogGroup",
-      "logs:UntagLogGroup",
+      "cloudformation:CreateStack"
     ]
     resources = ["*"]
   }
 
-  # Allow CloudFormation to publish status changes to the SNS queue
+  # Allow to pass the cloudfront role to the cloudformation stack
   statement {
-    effect = "Allow"
     actions = [
-      "sns:Publish"
+      "iam:PassRole"
     ]
-    resources = [var.deploy_status_sns_topic_arn]
+    resources = [var.cloudformation_role_arn]
   }
 }
 
@@ -254,13 +228,14 @@ module "deploy_trigger" {
   ]
 
   environment_variables = {
-    NODE_ENV               = "production"
-    TARGET_BUCKET          = aws_s3_bucket.static_deploy.id
-    DISTRIBUTION_ID        = var.cloudfront_id
-    SQS_QUEUE_URL          = aws_sqs_queue.this.id
-    DEPLOY_STATUS_SNS_ARN  = var.deploy_status_sns_topic_arn
-    TABLE_REGION           = var.dynamodb_region
-    TABLE_NAME_DEPLOYMENTS = var.dynamodb_table_deployments_name
+    NODE_ENV                = "production"
+    TARGET_BUCKET           = aws_s3_bucket.static_deploy.id
+    DISTRIBUTION_ID         = var.cloudfront_id
+    SQS_QUEUE_URL           = aws_sqs_queue.this.id
+    DEPLOY_STATUS_SNS_ARN   = var.deploy_status_sns_topic_arn
+    TABLE_REGION            = var.dynamodb_region
+    TABLE_NAME_DEPLOYMENTS  = var.dynamodb_table_deployments_name
+    CLOUDFORMATION_ROLE_ARN = var.cloudformation_role_arn
   }
 
   event_source_mapping = {

--- a/modules/statics-deploy/variables.tf
+++ b/modules/statics-deploy/variables.tf
@@ -18,6 +18,15 @@ variable "lambda_role_permissions_boundary" {
   default = null
 }
 
+################
+# CloudFormation
+################
+
+variable "cloudformation_role_arn" {
+  description = "Role ARN that should be assigned to the CloudFormation substacks created by CDK."
+  type        = string
+}
+
 #####################
 # Deployment database
 #####################

--- a/packages/api/schema.ts
+++ b/packages/api/schema.ts
@@ -125,7 +125,13 @@ export interface paths {
         };
       };
       responses: {
-        /** Successful response. */
+        /** Deletion successfully requested. */
+        200: {
+          content: {
+            'application/json': components['schemas']['Deployment'];
+          };
+        };
+        /** Successful deletion. */
         204: never;
         400: components['responses']['InvalidParamsError'];
       };
@@ -156,7 +162,8 @@ export interface components {
       | 'CREATE_FAILED'
       | 'FINISHED'
       | 'DESTROY_IN_PROGRESS'
-      | 'DESTROY_FAILED';
+      | 'DESTROY_FAILED'
+      | 'DESTROY_REQUESTED';
     DeploymentInitialized: {
       id: string;
       status: components['schemas']['DeploymentStatus'];

--- a/packages/api/schema.yaml
+++ b/packages/api/schema.yaml
@@ -63,6 +63,7 @@ components:
         - FINISHED
         - DESTROY_IN_PROGRESS
         - DESTROY_FAILED
+        - DESTROY_REQUESTED
 
     DeploymentInitialized:
       type: object
@@ -271,7 +272,13 @@ paths:
           required: true
           description: The id of the deployment to delete.
       responses:
+        '200':
+          description: Deletion successfully requested.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Deployment'
         '204':
-          description: Successful response.
+          description: Successful deletion.
         '400':
           $ref: '#/components/responses/InvalidParamsError'

--- a/packages/api/src/actions/deployment/get-deployment-by-id.ts
+++ b/packages/api/src/actions/deployment/get-deployment-by-id.ts
@@ -2,6 +2,7 @@ import { getDeploymentById as dynamoDBgetDeploymentById } from '@millihq/tfn-dyn
 import { Request, Response } from 'lambda-api';
 
 import { paths } from '../../../schema';
+import { deploymentDefaultSerializer } from '../../serializers/deployment';
 import { DynamoDBServiceType } from '../../services/dynamodb';
 
 type SuccessResponse =
@@ -20,13 +21,13 @@ async function getDeploymentById(
     throw new Error('Could not get deploymentId from path');
   }
 
-  const result = await dynamoDBgetDeploymentById({
+  const deployment = await dynamoDBgetDeploymentById({
     dynamoDBClient: dynamoDB.getDynamoDBClient(),
     deploymentTableName: dynamoDB.getDeploymentTableName(),
     deploymentId,
   });
 
-  if (!result) {
+  if (!deployment) {
     res.status(404);
     return {
       status: 404,
@@ -35,14 +36,7 @@ async function getDeploymentById(
     };
   }
 
-  return {
-    // Required attributes
-    id: result.DeploymentId,
-    createDate: result.CreateDate,
-    status: result.Status,
-    // Optional attributes
-    deploymentAlias: result.DeploymentAlias,
-  };
+  return deploymentDefaultSerializer(deployment);
 }
 
 export { getDeploymentById };

--- a/packages/api/src/actions/deployment/list-deployments.ts
+++ b/packages/api/src/actions/deployment/list-deployments.ts
@@ -2,6 +2,7 @@ import { listDeployments as dynamoDBlistDeployments } from '@millihq/tfn-dynamod
 import { Request, Response } from 'lambda-api';
 
 import { paths } from '../../../schema';
+import { deploymentDefaultSerializer } from '../../serializers/deployment';
 import { DynamoDBServiceType } from '../../services/dynamodb';
 
 /**
@@ -58,13 +59,7 @@ async function listDeployments(
     metadata: {
       next: nextKey,
     },
-    items: items.map((item) => {
-      return {
-        id: item.DeploymentId,
-        createDate: item.CreateDate,
-        status: item.Status,
-      };
-    }),
+    items: items.map(deploymentDefaultSerializer),
   };
 }
 

--- a/packages/api/src/serializers/deployment.ts
+++ b/packages/api/src/serializers/deployment.ts
@@ -1,0 +1,29 @@
+import { DeploymentItem } from '@millihq/tfn-dynamodb-actions';
+
+import { components } from '../../schema';
+
+type Deployment = components['schemas']['Deployment'];
+
+/* -----------------------------------------------------------------------------
+ * deploymentDefaultSerializer
+ * ---------------------------------------------------------------------------*/
+
+type DeploymentDefaultSerializerInput = Pick<
+  DeploymentItem,
+  'DeploymentId' | 'CreateDate' | 'Status' | 'DeploymentAlias'
+>;
+
+function deploymentDefaultSerializer<
+  DeploymentInput extends DeploymentDefaultSerializerInput
+>(deployment: DeploymentInput): Deployment {
+  return {
+    // Required attributes
+    id: deployment.DeploymentId,
+    createDate: deployment.CreateDate,
+    status: deployment.Status,
+    // Optional attributes
+    deploymentAlias: deployment.DeploymentAlias,
+  };
+}
+
+export { deploymentDefaultSerializer };

--- a/packages/api/test/actions/deployment/delete-deployment-by-id.test.ts
+++ b/packages/api/test/actions/deployment/delete-deployment-by-id.test.ts
@@ -204,8 +204,11 @@ describe('DeleteDeployment', () => {
     )) as APIGatewayProxyStructuredResultV2;
     expect(response).toMatchObject({
       headers: { 'content-type': 'application/json' },
-      statusCode: 204,
+      statusCode: 200,
       isBase64Encoded: false,
+    });
+    expect(JSON.parse(response.body!)).toMatchObject({
+      status: 'DESTROY_REQUESTED',
     });
     expect(deleteStackSpy).toHaveBeenCalledTimes(1);
   });

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "experimentalDecorators": true,
-    "strictPropertyInitialization": false
+    "strictPropertyInitialization": false,
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["schema.ts", "./src/**/*", "./test/**/*"]
 }

--- a/packages/deploy-controller/src/controller.ts
+++ b/packages/deploy-controller/src/controller.ts
@@ -1,0 +1,188 @@
+import {
+  createAlias,
+  deleteDeploymentById,
+  reverseHostname,
+  updateDeploymentStatus,
+  updateDeploymentStatusFinished,
+  updateDeploymentStatusCreateFailed,
+  updateDeploymentStatusDestroyInProgress,
+  updateDeploymentStatusDestroyFailed,
+} from '@millihq/tfn-dynamodb-actions';
+import { SNSEvent } from 'aws-lambda';
+import CloudFormation from 'aws-sdk/clients/cloudformation';
+import DynamoDB from 'aws-sdk/clients/dynamodb';
+
+import { parseCloudFormationEvent } from './utils/parse-cloudformation-event';
+import { parseLambdaRoutes } from './utils/parse-lambda-routes';
+
+type ControllerOptions = {
+  dynamoDBClient: DynamoDB;
+  cloudFormationClient?: CloudFormation;
+};
+
+type RuntimeOptions = {
+  aliasTableName: string;
+  deploymentTableName: string;
+};
+
+class Controller {
+  cloudFormationClient: CloudFormation;
+  dynamoDBClient: DynamoDB;
+
+  constructor({ dynamoDBClient, cloudFormationClient }: ControllerOptions) {
+    this.cloudFormationClient = cloudFormationClient ?? new CloudFormation();
+    this.dynamoDBClient = dynamoDBClient;
+  }
+
+  run = async (
+    event: SNSEvent,
+    { aliasTableName, deploymentTableName }: RuntimeOptions
+  ) => {
+    await Promise.all(
+      event.Records.map(async (record) => {
+        const message = record.Sns.Message;
+        const parsedEvent = parseCloudFormationEvent(message);
+
+        const { ResourceType, ResourceStatus, StackName } = parsedEvent;
+
+        // Only handle stack related events
+        if (ResourceType !== 'AWS::CloudFormation::Stack') {
+          return;
+        }
+
+        if (typeof ResourceStatus !== 'string') {
+          throw new Error('No attribute `ResourceStatus` present in event');
+        }
+
+        if (typeof StackName !== 'string') {
+          throw new Error('No attribute `StackName` present in event');
+        }
+
+        // Remove the `tfn-` prefix from the stack name to get the deploymentID
+        const deploymentId = StackName.slice(4);
+
+        /**
+         * The following values for resource status are possible:
+         * {@link CloudFormation.StackStatus}
+         */
+        switch (ResourceStatus) {
+          case 'CREATE_COMPLETE':
+            const stackARN = parsedEvent.StackId;
+            if (!stackARN) {
+              throw new Error('CreateComplete: No StackId present');
+            }
+
+            // Get the stack that triggered the event
+            const stacksResponse = await this.cloudFormationClient
+              .describeStacks({
+                StackName: stackARN,
+              })
+              .promise();
+
+            if (!stacksResponse.Stacks || stacksResponse.Stacks.length !== 1) {
+              throw new Error(
+                'CreateComplete: Could not retrieve stack with id: ' + stackARN
+              );
+            }
+
+            const stack = stacksResponse.Stacks[0];
+            const lambdaRoutesStackOutput = stack.Outputs?.find(
+              ({ OutputKey }) => OutputKey === 'lambdaRoutes'
+            );
+
+            let lambdaRoutes: Record<string, string> = {};
+            if (
+              lambdaRoutesStackOutput &&
+              lambdaRoutesStackOutput.OutputValue
+            ) {
+              lambdaRoutes = parseLambdaRoutes(
+                lambdaRoutesStackOutput.OutputValue
+              );
+            }
+
+            const stringifiedLambdaRoutes = JSON.stringify(lambdaRoutes);
+
+            const deployment = await updateDeploymentStatus({
+              dynamoDBClient: this.dynamoDBClient,
+              deploymentId,
+              deploymentTableName,
+              lambdaRoutes: stringifiedLambdaRoutes,
+              newStatus: 'CREATE_COMPLETE',
+            });
+
+            // TODO: Handle case when multi deployments is not enabled
+            const deploymentAliasBasePath = '/';
+            const deploymentAliasHostname =
+              deploymentId + process.env.MULTI_DEPLOYMENTS_BASE_DOMAIN;
+            const deploymentAliasHostnameRev = reverseHostname(
+              deploymentAliasHostname
+            );
+            await createAlias({
+              dynamoDBClient: this.dynamoDBClient,
+              hostnameRev: deploymentAliasHostnameRev,
+              isDeploymentAlias: true,
+              aliasTableName,
+              createDate: new Date(),
+              deploymentId,
+              lambdaRoutes: stringifiedLambdaRoutes,
+              // Copy values over from the deployment
+              routes: deployment.Routes,
+              prerenders: deployment.Prerenders,
+              basePath: deploymentAliasBasePath,
+            });
+
+            await updateDeploymentStatusFinished({
+              dynamoDBClient: this.dynamoDBClient,
+              deploymentId,
+              deploymentTableName,
+              deploymentAlias:
+                deploymentAliasHostname + deploymentAliasBasePath,
+            });
+            break;
+
+          case 'CREATE_FAILED':
+            await updateDeploymentStatusCreateFailed({
+              dynamoDBClient: this.dynamoDBClient,
+              deploymentTableName,
+              deploymentId,
+            });
+            break;
+
+          case 'DELETE_COMPLETE':
+            await deleteDeploymentById({
+              dynamoDBClient: this.dynamoDBClient,
+              deploymentTableName,
+              deploymentId,
+            });
+            break;
+
+          case 'DELETE_IN_PROGRESS':
+            await updateDeploymentStatusDestroyInProgress({
+              dynamoDBClient: this.dynamoDBClient,
+              deploymentTableName,
+              deploymentId,
+            });
+            break;
+
+          case 'DELETE_FAILED':
+            await updateDeploymentStatusDestroyFailed({
+              dynamoDBClient: this.dynamoDBClient,
+              deploymentTableName,
+              deploymentId,
+            });
+            break;
+
+          default:
+          // Event is not handled, since it is not relevant
+        }
+      })
+    );
+  };
+}
+
+function createController(options: ControllerOptions) {
+  return new Controller(options);
+}
+
+export type { Controller };
+export { createController };

--- a/packages/deploy-controller/src/handler.ts
+++ b/packages/deploy-controller/src/handler.ts
@@ -1,21 +1,17 @@
-import {
-  createAlias,
-  reverseHostname,
-  updateDeploymentStatus,
-  updateDeploymentStatusFinished,
-} from '@millihq/tfn-dynamodb-actions';
 import { SNSEvent } from 'aws-lambda';
 import DynamoDB from 'aws-sdk/clients/dynamodb';
-import CloudFormation from 'aws-sdk/clients/cloudformation';
 
 import { ensureEnv } from './utils/ensure-env';
-import { parseCloudFormationEvent } from './utils/parse-cloudformation-event';
-import { parseLambdaRoutes } from './utils/parse-lambda-routes';
+import { createController } from './controller';
 
 const dynamoDBRegion = ensureEnv('TABLE_REGION');
 
 const dynamoDBClient = new DynamoDB({
   region: dynamoDBRegion,
+});
+
+const controller = createController({
+  dynamoDBClient,
 });
 
 /**
@@ -26,120 +22,14 @@ async function handler(event: SNSEvent) {
   const dynamoDBTableNameDeployments = ensureEnv('TABLE_NAME_DEPLOYMENTS');
   const dynamoDBTableNameAliases = ensureEnv('TABLE_NAME_ALIASES');
 
-  await Promise.all(
-    event.Records.map(async (record) => {
-      const message = record.Sns.Message;
-      const parsedEvent = parseCloudFormationEvent(message);
-
-      const { ResourceType, ResourceStatus, StackName } = parsedEvent;
-
-      // Only handle stack related events
-      if (ResourceType !== 'AWS::CloudFormation::Stack') {
-        return;
-      }
-
-      if (ResourceStatus === undefined) {
-        console.error('Error: No attribute `ResourceStatus` present in event.');
-        return;
-      }
-
-      if (StackName === undefined) {
-        console.error('Error: No attribute `StackName` present in event.');
-        return;
-      }
-
-      // Remove the `tfn-` prefix from the stack name to get the deploymentID
-      const deploymentId = StackName.slice(4);
-
-      switch (ResourceStatus) {
-        case 'CREATE_COMPLETE':
-          try {
-            const stackARN = parsedEvent.StackId;
-            if (!stackARN) {
-              throw new Error('No StackId present');
-            }
-
-            const cloudformationClient = new CloudFormation();
-            // Get the stack that triggered the event
-            const stacksResponse = await cloudformationClient
-              .describeStacks({
-                StackName: stackARN,
-              })
-              .promise();
-
-            if (!stacksResponse.Stacks || stacksResponse.Stacks.length !== 1) {
-              throw new Error('Could not retrieve stack with id: ' + stackARN);
-            }
-
-            const stack = stacksResponse.Stacks[0];
-            const lambdaRoutesStackOutput = stack.Outputs?.find(
-              ({ OutputKey }) => OutputKey === 'lambdaRoutes'
-            );
-
-            console.log({ stack: JSON.stringify(stack, null, 2) });
-
-            let lambdaRoutes: Record<string, string> = {};
-            if (
-              lambdaRoutesStackOutput &&
-              lambdaRoutesStackOutput.OutputValue
-            ) {
-              lambdaRoutes = parseLambdaRoutes(
-                lambdaRoutesStackOutput.OutputValue
-              );
-            }
-
-            const stringifiedLambdaRoutes = JSON.stringify(lambdaRoutes);
-
-            const deployment = await updateDeploymentStatus({
-              dynamoDBClient,
-              deploymentId,
-              deploymentTableName: dynamoDBTableNameDeployments,
-              lambdaRoutes: stringifiedLambdaRoutes,
-              newStatus: 'CREATE_COMPLETE',
-            });
-
-            // TODO: Handle case when multi deployments is not enabled
-            const deploymentAliasBasePath = '/';
-            const deploymentAliasHostname =
-              deploymentId + process.env.MULTI_DEPLOYMENTS_BASE_DOMAIN;
-            const deploymentAliasHostnameRev = reverseHostname(
-              deploymentId + process.env.MULTI_DEPLOYMENTS_BASE_DOMAIN
-            );
-            await createAlias({
-              dynamoDBClient,
-              hostnameRev: deploymentAliasHostnameRev,
-              isDeploymentAlias: true,
-              aliasTableName: dynamoDBTableNameAliases,
-              createDate: new Date(),
-              deploymentId,
-              lambdaRoutes: stringifiedLambdaRoutes,
-              // Copy values over from the deployment
-              routes: deployment.Routes,
-              prerenders: deployment.Prerenders,
-              basePath: deploymentAliasBasePath,
-            });
-
-            await updateDeploymentStatusFinished({
-              dynamoDBClient,
-              deploymentId,
-              deploymentTableName: dynamoDBTableNameDeployments,
-              deploymentAlias:
-                deploymentAliasHostname + deploymentAliasBasePath,
-            });
-          } catch (error) {
-            console.log('ERROR', error);
-          }
-
-        case 'DELETE_COMPLETE':
-
-        case 'CREATE_FAILED':
-        // TODO: Inform about failed deployment
-
-        default:
-        // Event is not handled, since it is not relevant
-      }
-    })
-  );
+  try {
+    await controller.run(event, {
+      aliasTableName: dynamoDBTableNameAliases,
+      deploymentTableName: dynamoDBTableNameDeployments,
+    });
+  } catch (error) {
+    console.error(error);
+  }
 }
 
 export { handler };

--- a/packages/deploy-controller/test/controller.test.ts
+++ b/packages/deploy-controller/test/controller.test.ts
@@ -1,0 +1,76 @@
+import {
+  createTestDynamoDBClient,
+  createAliasTestTable,
+  createDeploymentTestTable,
+} from '@millihq/tfn-dynamodb-actions/test/test-utils';
+import DynamoDB from 'aws-sdk/clients/dynamodb';
+
+import { Controller, createController } from '../src/controller';
+import { createTestSNSEvent } from './test-utils';
+
+describe('Deploy Controller', () => {
+  let controller: Controller;
+  let dynamoDBClient: DynamoDB;
+  let aliasTableName: string;
+  let deploymentTableName: string;
+
+  beforeAll(async () => {
+    dynamoDBClient = createTestDynamoDBClient();
+    aliasTableName = await createAliasTestTable(dynamoDBClient);
+    deploymentTableName = await createDeploymentTestTable(dynamoDBClient);
+  });
+
+  beforeEach(() => {
+    controller = createController({
+      dynamoDBClient,
+    });
+  });
+
+  afterAll(async () => {
+    await dynamoDBClient.deleteTable({
+      TableName: aliasTableName,
+    });
+    await dynamoDBClient.deleteTable({
+      TableName: deploymentTableName,
+    });
+  });
+
+  test('No ResourceStatus present in event', async () => {
+    const event = createTestSNSEvent({
+      ResourceStatus: null,
+    });
+    await expect(
+      controller.run(event, {
+        aliasTableName,
+        deploymentTableName,
+      })
+    ).rejects.toThrow(
+      new Error('No attribute `ResourceStatus` present in event')
+    );
+  });
+
+  test('No StackName present in event', async () => {
+    const event = createTestSNSEvent({
+      StackName: null,
+    });
+    await expect(
+      controller.run(event, {
+        aliasTableName,
+        deploymentTableName,
+      })
+    ).rejects.toThrow(new Error('No attribute `StackName` present in event'));
+  });
+
+  test('CreateComplete: No StackId present in event', async () => {
+    const event = createTestSNSEvent({
+      ResourceStatus: 'CREATE_COMPLETE',
+      StackId: null,
+    });
+    await expect(
+      controller.run(event, {
+        aliasTableName,
+        deploymentTableName,
+      })
+    ).rejects.toThrow(new Error('CreateComplete: No StackId present'));
+  });
+});

--- a/packages/deploy-controller/test/test-utils.ts
+++ b/packages/deploy-controller/test/test-utils.ts
@@ -1,0 +1,84 @@
+import { SNSEvent } from 'aws-lambda';
+
+type CreateTestMessageOptions = {
+  StackId?: string | null;
+  Timestamp?: string | null;
+  EventId?: string | null;
+  LogicalResourceId?: string | null;
+  Namespace?: string | null;
+  PhysicalResourceId?: string | null;
+  ResourceProperties?: string | null;
+  ResourceStatus?: string | null;
+  ResourceStatusReason?: string | null;
+  ResourceType?: string | null;
+  StackName?: string | null;
+  ClientRequestToken?: string | null;
+};
+
+const defaultMessageContent: Record<keyof CreateTestMessageOptions, string> = {
+  StackId:
+    'arn:aws:cloudformation:eu-central-1:238476290347:stack/tfn-d35de1a94815e0562689b89b6225cd85/319a93a0-c3df-11ec-9e1a-0a226e11de6a',
+  Timestamp: '2022-04-24T15:00:11.646Z',
+  EventId: 'lambdaRoleC844FDB1-CREATE_COMPLETE-2022-04-24T15:00:11.646Z',
+  LogicalResourceId: 'lambdaRoleC844FDB1',
+  Namespace: '238476290347',
+  PhysicalResourceId:
+    'fn-d35de1a94815e0562689b89b622-lambdaRoleC844FDB1-3O50QZY56BMU',
+  ResourceProperties:
+    '{"Description":"Managed by Terraform Next.js","AssumeRolePolicyDocument":{"Version":"2012-10-17","Statement":[{"Action":"sts:AssumeRole","Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"}}]}}',
+  ResourceStatus: 'CREATE_COMPLETE',
+  ResourceStatusReason: '',
+  ResourceType: 'AWS::CloudFormation::Stack',
+  StackName: 'tfn-d35de1a94815e0562689b89b6225cd85',
+  ClientRequestToken: 'null',
+};
+
+function createTestMessage(options: CreateTestMessageOptions = {}): string {
+  return Object.entries(defaultMessageContent).reduce(
+    (acc, [_key, defaultValue]) => {
+      const key = _key as keyof CreateTestMessageOptions;
+      const optionsValue = options[key];
+      let value: string;
+
+      if (optionsValue === null) {
+        // Dont set value
+        return acc;
+      } else if (optionsValue === undefined) {
+        // Use default value
+        value = defaultValue;
+      } else {
+        value = optionsValue;
+      }
+
+      return acc + `${key}='${value}'\n`;
+    },
+    ''
+  );
+}
+
+function createTestSNSEvent(options: CreateTestMessageOptions = {}): SNSEvent {
+  return {
+    Records: [
+      {
+        EventVersion: '',
+        EventSubscriptionArn: '',
+        EventSource: '',
+        Sns: {
+          SignatureVersion: '',
+          Timestamp: '',
+          Signature: '',
+          SigningCertUrl: '',
+          MessageId: '',
+          Message: createTestMessage(options),
+          MessageAttributes: {},
+          Type: '',
+          UnsubscribeUrl: '',
+          TopicArn: '',
+          Subject: '',
+        },
+      },
+    ],
+  };
+}
+
+export { createTestSNSEvent };

--- a/packages/deploy-controller/tsconfig.json
+++ b/packages/deploy-controller/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["./src/**/*", "./test/**/*"]
 }

--- a/packages/deploy-trigger/src/cdk/create-cloudformation-stack.ts
+++ b/packages/deploy-trigger/src/cdk/create-cloudformation-stack.ts
@@ -18,12 +18,17 @@ type CreateCloudFormationStackOptions = {
   notificationARNs: string[];
   stack: Stack;
   stackName: string;
+  /**
+   * ARN of the role that should be used for managing the CloudFormation stack.
+   */
+  cloudFormationRoleArn: string;
 };
 
 async function createCloudFormationStack({
   notificationARNs,
   stack,
   stackName,
+  cloudFormationRoleArn,
 }: CreateCloudFormationStackOptions): Promise<CreateCloudFormationStackReturnValue> {
   const cloudformationClient = new CloudFormation();
   const template = toCloudFormation(stack);
@@ -34,6 +39,7 @@ async function createCloudFormationStack({
       NotificationARNs: notificationARNs,
       StackName: stackName,
       TemplateBody: JSON.stringify(template),
+      RoleARN: cloudFormationRoleArn,
     })
     .promise();
 

--- a/packages/deploy-trigger/src/declarations.d.ts
+++ b/packages/deploy-trigger/src/declarations.d.ts
@@ -6,5 +6,6 @@ declare namespace NodeJS {
     DEPLOY_STATUS_SNS_ARN: string;
     TABLE_REGION: string;
     TABLE_NAME_DEPLOYMENTS: string;
+    CLOUDFORMATION_ROLE_ARN: string;
   }
 }

--- a/packages/dynamodb-actions/README.md
+++ b/packages/dynamodb-actions/README.md
@@ -106,14 +106,19 @@ The following actions on the database are supported:
 
 - `createDeployment`  
   Inserts a new deployment into the DeploymentTable.
-- `listDeployments`  
-  Lists all deployments from the DeploymentTable, sorted by `CreateDate` DESC.
+- `deleteDeploymentById`
 - `getDeploymentById`  
   Returns the Deployment for the given ID. Returns `null` when it does not exist.
-- `deleteDeploymentById`
-- `updateDeploymentStatus`
+- `listDeployments`  
+  Lists all deployments from the DeploymentTable, sorted by `CreateDate` DESC.
+- `updateDeploymentStatusCreateFailed`
 - `updateDeploymentStatusCreateInProgress`
+- `updateDeploymentStatusDestroyFailed`
+- `updateDeploymentStatusDestroyInProgress`
+- `updateDeploymentStatus`
+- `updateDeploymentStatusDestroyRequested`
 - `updateDeploymentStatusFinished`
+- `updateDeploymentStatus`
 
 ### Aliases
 

--- a/packages/dynamodb-actions/src/deployment/update-deployment-status-create-failed.ts
+++ b/packages/dynamodb-actions/src/deployment/update-deployment-status-create-failed.ts
@@ -1,0 +1,41 @@
+import DynamoDB from 'aws-sdk/clients/dynamodb';
+
+import { updateDeployment } from './update-deployment';
+
+type UpdateDeploymentStatusCreateFailed = {
+  /**
+   * DynamoDB client
+   */
+  dynamoDBClient: DynamoDB;
+  /**
+   * Name of the table that holds the deployments.
+   */
+  deploymentTableName: string;
+  /**
+   * ID of the deployment.
+   */
+  deploymentId: string | { PK: string; SK: string };
+};
+
+/**
+ * Updates the status of an existing deployment to create failed state.
+ *
+ * @param options
+ * @returns
+ */
+function updateDeploymentStatusCreateFailed({
+  dynamoDBClient,
+  deploymentTableName,
+  deploymentId,
+}: UpdateDeploymentStatusCreateFailed) {
+  return updateDeployment({
+    dynamoDBClient,
+    deploymentTableName,
+    deploymentId,
+    updateAttributes: {
+      Status: 'CREATE_FAILED',
+    },
+  });
+}
+
+export { updateDeploymentStatusCreateFailed };

--- a/packages/dynamodb-actions/src/deployment/update-deployment-status-destroy-failed.ts
+++ b/packages/dynamodb-actions/src/deployment/update-deployment-status-destroy-failed.ts
@@ -1,0 +1,41 @@
+import DynamoDB from 'aws-sdk/clients/dynamodb';
+
+import { updateDeployment } from './update-deployment';
+
+type UpdateDeploymentStatusDestroyFailed = {
+  /**
+   * DynamoDB client
+   */
+  dynamoDBClient: DynamoDB;
+  /**
+   * Name of the table that holds the deployments.
+   */
+  deploymentTableName: string;
+  /**
+   * ID of the deployment.
+   */
+  deploymentId: string | { PK: string; SK: string };
+};
+
+/**
+ * Updates the status of an existing deployment to DESTROY_FAILED.
+ *
+ * @param options
+ * @returns
+ */
+function updateDeploymentStatusDestroyFailed({
+  dynamoDBClient,
+  deploymentTableName,
+  deploymentId,
+}: UpdateDeploymentStatusDestroyFailed) {
+  return updateDeployment({
+    dynamoDBClient,
+    deploymentTableName,
+    deploymentId,
+    updateAttributes: {
+      Status: 'DESTROY_FAILED',
+    },
+  });
+}
+
+export { updateDeploymentStatusDestroyFailed };

--- a/packages/dynamodb-actions/src/deployment/update-deployment-status-destroy-requested.ts
+++ b/packages/dynamodb-actions/src/deployment/update-deployment-status-destroy-requested.ts
@@ -1,0 +1,41 @@
+import DynamoDB from 'aws-sdk/clients/dynamodb';
+
+import { updateDeployment } from './update-deployment';
+
+type UpdateDeploymentStatusDestroyRequested = {
+  /**
+   * DynamoDB client
+   */
+  dynamoDBClient: DynamoDB;
+  /**
+   * Name of the table that holds the deployments.
+   */
+  deploymentTableName: string;
+  /**
+   * ID of the deployment.
+   */
+  deploymentId: string | { PK: string; SK: string };
+};
+
+/**
+ * Updates the status of an existing deployment to DESTROY_REQUESTED.
+ *
+ * @param options
+ * @returns
+ */
+function updateDeploymentStatusDestroyRequested({
+  dynamoDBClient,
+  deploymentTableName,
+  deploymentId,
+}: UpdateDeploymentStatusDestroyRequested) {
+  return updateDeployment({
+    dynamoDBClient,
+    deploymentTableName,
+    deploymentId,
+    updateAttributes: {
+      Status: 'DESTROY_REQUESTED',
+    },
+  });
+}
+
+export { updateDeploymentStatusDestroyRequested };

--- a/packages/dynamodb-actions/src/index.ts
+++ b/packages/dynamodb-actions/src/index.ts
@@ -14,6 +14,7 @@ export { updateDeploymentStatus } from './deployment/update-deployment-status';
 export { updateDeploymentStatusCreateInProgress } from './deployment/update-deployment-status-create-in-progress';
 export { updateDeploymentStatusFinished } from './deployment/update-deployment-status-finished';
 export { updateDeploymentStatusDestroyInProgress } from './deployment/update-deployment-status-destroy-in-progress';
+export { updateDeploymentStatusCreateFailed } from './deployment/update-deployment-status-create-failed';
 
 // Utils
 export { reverseHostname } from './utils/reverse-hostname';

--- a/packages/dynamodb-actions/src/index.ts
+++ b/packages/dynamodb-actions/src/index.ts
@@ -7,14 +7,16 @@ export { listAliasesForDeployment } from './alias/list-aliases-for-deployment';
 
 // Deployment
 export { createDeployment } from './deployment/create-deployment';
-export { listDeployments } from './deployment/list-deployments';
-export { getDeploymentById } from './deployment/get-deployment-by-id';
 export { deleteDeploymentById } from './deployment/delete-deployment-by-id';
-export { updateDeploymentStatus } from './deployment/update-deployment-status';
-export { updateDeploymentStatusCreateInProgress } from './deployment/update-deployment-status-create-in-progress';
-export { updateDeploymentStatusFinished } from './deployment/update-deployment-status-finished';
-export { updateDeploymentStatusDestroyInProgress } from './deployment/update-deployment-status-destroy-in-progress';
+export { getDeploymentById } from './deployment/get-deployment-by-id';
+export { listDeployments } from './deployment/list-deployments';
 export { updateDeploymentStatusCreateFailed } from './deployment/update-deployment-status-create-failed';
+export { updateDeploymentStatusCreateInProgress } from './deployment/update-deployment-status-create-in-progress';
+export { updateDeploymentStatusDestroyFailed } from './deployment/update-deployment-status-destroy-failed';
+export { updateDeploymentStatusDestroyInProgress } from './deployment/update-deployment-status-destroy-in-progress';
+export { updateDeploymentStatusDestroyRequested } from './deployment/update-deployment-status-destroy-requested';
+export { updateDeploymentStatusFinished } from './deployment/update-deployment-status-finished';
+export { updateDeploymentStatus } from './deployment/update-deployment-status';
 
 // Utils
 export { reverseHostname } from './utils/reverse-hostname';

--- a/packages/dynamodb-actions/src/types.ts
+++ b/packages/dynamodb-actions/src/types.ts
@@ -39,7 +39,8 @@ export type DeploymentItem = {
     | 'CREATE_FAILED'
     | 'FINISHED'
     | 'DESTROY_IN_PROGRESS'
-    | 'DESTROY_FAILED';
+    | 'DESTROY_FAILED'
+    | 'DESTROY_REQUESTED';
   /**
    * Version of the item
    */

--- a/packages/tf-next/src/client/services/api/api.ts
+++ b/packages/tf-next/src/client/services/api/api.ts
@@ -27,6 +27,8 @@ type ListDeploymentsSuccessResponse =
   paths['/deployments']['get']['responses']['200']['content']['application/json'];
 type GetDeploymentByIdSuccessResponse =
   paths['/deployments/{deploymentId}']['get']['responses']['200']['content']['application/json'];
+type DeleteDeploymentByIdSuccessResponse =
+  paths['/deployments/{deploymentId}']['delete']['responses']['200']['content']['application/json'];
 
 const POLLING_DEFAULT_INTERVAL_MS = 5_000;
 const POLLING_DEFAULT_TIMEOUT_MS = 5 * 60_000;
@@ -270,11 +272,14 @@ class ApiService {
     return result;
   };
 
-  deleteDeploymentById(deploymentId: string) {
-    return this.fetchAWSSigV4(`/deployments/${deploymentId}`, {
-      method: 'DELETE',
-    });
-  }
+  deleteDeploymentById = (deploymentId: string) => {
+    return this.fetchAWSSigV4<undefined | DeleteDeploymentByIdSuccessResponse>(
+      `/deployments/${deploymentId}`,
+      {
+        method: 'DELETE',
+      }
+    );
+  };
 }
 
 export { ApiService };

--- a/packages/tf-next/src/client/services/api/api.ts
+++ b/packages/tf-next/src/client/services/api/api.ts
@@ -8,7 +8,10 @@ import { Credentials } from 'aws-lambda';
 import nodeFetch, { HeadersInit } from 'node-fetch';
 import pWaitFor from 'p-wait-for';
 
-import { createResponseError } from '../../../utils/errors/response-error';
+import {
+  createResponseError,
+  ResponseError,
+} from '../../../utils/errors/response-error';
 
 type NodeFetch = typeof nodeFetch;
 type CreateAliasRequestBody =
@@ -239,7 +242,11 @@ class ApiService {
 
         if (response) {
           if (failureStatus.indexOf(response.status) !== -1) {
-            throw new Error('Deployment failed.');
+            // Create a pseudo error response
+            throw new ResponseError({
+              status: 400,
+              code: 'DEPLOYMENT_CREATE_FAILED',
+            });
           }
 
           if (response.status === status) {

--- a/packages/tf-next/src/client/services/output/output.ts
+++ b/packages/tf-next/src/client/services/output/output.ts
@@ -31,7 +31,7 @@ class OutputService {
   }
 
   log = (message: string, color = chalk.grey) => {
-    this.print(`${color('>')} ${message}`);
+    this.print(message, color('> '));
   };
 
   debug = (message: string) => {

--- a/packages/tf-next/src/commands/deployment/deployment-list.ts
+++ b/packages/tf-next/src/commands/deployment/deployment-list.ts
@@ -43,6 +43,15 @@ async function deploymentListCommand({ client }: DeploymentListCommandOptions) {
   const deployments = await apiService.listDeployments();
   output.stopSpinner();
 
+  if (deployments.length === 0) {
+    output.log(
+      `No deployments created yet.\n${chalk.gray(
+        'Create a new deployment by running `tf-next deploy`.'
+      )}`
+    );
+    return;
+  }
+
   const todayMillis = Date.now();
   console.log(
     table(

--- a/packages/tf-next/src/utils/errors/errors.ts
+++ b/packages/tf-next/src/utils/errors/errors.ts
@@ -56,3 +56,13 @@ export class DeploymentHasLinkedAliases extends CliError<'DEPLOYMENT_HAS_CUSTOM_
     });
   }
 }
+
+export class DeploymentCreateFailed extends CliError<'DEPLOYMENT_CREATE_FAILED'> {
+  constructor() {
+    super({
+      code: 'DEPLOYMENT_CREATE_FAILED',
+      message:
+        'Creation of the deployment failed. Please see the logs in AWS CloudWatch for more information.',
+    });
+  }
+}


### PR DESCRIPTION
Assigns each substack created by CDK a common role that is used when the stack is modified (Created / Destroyed).
This removes a lot of permissions from the deployment-trigger Lambda which improves security.