### PR TITLE
Fixes deployments without Lambdas

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -174,8 +174,7 @@ data "aws_iam_policy_document" "cloudformation_permission_assume_role" {
 }
 
 resource "aws_iam_policy" "cloudformation_permission" {
-  name        = "cloudformation-control"
-  path        = "/${var.deployment_name}/"
+  name        = "${var.deployment_name}_cf-control"
   description = "Managed by Terraform Next.js"
   policy      = data.aws_iam_policy_document.cloudformation_permission.json
 
@@ -183,8 +182,7 @@ resource "aws_iam_policy" "cloudformation_permission" {
 }
 
 resource "aws_iam_role" "cloudformation_permission" {
-  name               = "cloudformation-control"
-  path               = "/${var.deployment_name}/"
+  name               = "${var.deployment_name}_cf-control"
   assume_role_policy = data.aws_iam_policy_document.cloudformation_permission_assume_role.json
   managed_policy_arns = [
     aws_iam_policy.cloudformation_permission.arn
@@ -227,10 +225,15 @@ module "statics_deploy" {
   deploy_status_sns_topic_arn = module.deploy_controller.sns_topic_arn
 
   dynamodb_region                 = data.aws_region.current.name
+  dynamodb_table_aliases_arn      = aws_dynamodb_table.aliases.arn
+  dynamodb_table_aliases_name     = aws_dynamodb_table.aliases.id
   dynamodb_table_deployments_arn  = aws_dynamodb_table.deployments.arn
   dynamodb_table_deployments_name = aws_dynamodb_table.deployments.id
 
   cloudformation_role_arn = aws_iam_role.cloudformation_permission.arn
+
+  enable_multiple_deployments      = var.enable_multiple_deployments
+  multiple_deployments_base_domain = var.multiple_deployments_base_domain
 
   lambda_role_permissions_boundary = var.lambda_role_permissions_boundary
 

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -143,8 +143,7 @@ data "aws_iam_policy_document" "access_api" {
 }
 
 resource "aws_iam_policy" "access_api" {
-  name = "api-access"
-  path = "/${var.deployment_name}/"
+  name = "${var.deployment_name}_api-access"
 
   description = "Managed by Terraform Next.js"
 

--- a/modules/statics-deploy/main.tf
+++ b/modules/statics-deploy/main.tf
@@ -153,7 +153,10 @@ data "aws_iam_policy_document" "access_dynamodb_table_deployments" {
       "dynamodb:PutItem",
       "dynamodb:UpdateItem"
     ]
-    resources = [var.dynamodb_table_deployments_arn]
+    resources = [
+      var.dynamodb_table_aliases_arn,
+      var.dynamodb_table_deployments_arn
+    ]
   }
 }
 
@@ -234,8 +237,11 @@ module "deploy_trigger" {
     SQS_QUEUE_URL           = aws_sqs_queue.this.id
     DEPLOY_STATUS_SNS_ARN   = var.deploy_status_sns_topic_arn
     TABLE_REGION            = var.dynamodb_region
+    TABLE_NAME_ALIASES      = var.dynamodb_table_aliases_name
     TABLE_NAME_DEPLOYMENTS  = var.dynamodb_table_deployments_name
     CLOUDFORMATION_ROLE_ARN = var.cloudformation_role_arn
+    # Remove the * from the base domain (e.g. *.example.com -> .example.com)
+    MULTI_DEPLOYMENTS_BASE_DOMAIN = var.enable_multiple_deployments ? replace(var.multiple_deployments_base_domain, "/^\\*/", "") : null
   }
 
   event_source_mapping = {

--- a/modules/statics-deploy/variables.tf
+++ b/modules/statics-deploy/variables.tf
@@ -27,11 +27,32 @@ variable "cloudformation_role_arn" {
   type        = string
 }
 
+######################
+# Multiple deployments
+######################
+
+variable "enable_multiple_deployments" {
+  type = bool
+}
+
+variable "multiple_deployments_base_domain" {
+  type    = string
+  default = null
+}
+
 #####################
 # Deployment database
 #####################
 
 variable "dynamodb_region" {
+  type = string
+}
+
+variable "dynamodb_table_aliases_arn" {
+  type = string
+}
+
+variable "dynamodb_table_aliases_name" {
   type = string
 }
 

--- a/packages/deploy-trigger/src/declarations.d.ts
+++ b/packages/deploy-trigger/src/declarations.d.ts
@@ -6,6 +6,8 @@ declare namespace NodeJS {
     DEPLOY_STATUS_SNS_ARN: string;
     TABLE_REGION: string;
     TABLE_NAME_DEPLOYMENTS: string;
+    TABLE_NAME_ALIASES: string;
     CLOUDFORMATION_ROLE_ARN: string;
+    MULTI_DEPLOYMENTS_BASE_DOMAIN?: string;
   }
 }

--- a/packages/dynamodb-actions/src/deployment/update-deployment-status-finished.ts
+++ b/packages/dynamodb-actions/src/deployment/update-deployment-status-finished.ts
@@ -19,6 +19,23 @@ type UpdateDeploymentStatusFinishedOptions = {
    * The alias that is assigned with this deployment.
    */
   deploymentAlias?: string;
+  /**
+   * Only used for static deployments.
+   * Stringified JSON object that contains routes that are served from
+   * prerendered generated HTML files.
+   *
+   */
+  prerenders?: string;
+  /**
+   * Only used for static deployments.
+   * Stringified JSON object that contains the route config.
+   */
+  routes?: string;
+  /**
+   * Only used for static deployments.
+   * Stringified routing table for Lambdas
+   */
+  lambdaRoutes?: string;
 };
 
 /**
@@ -32,6 +49,9 @@ function updateDeploymentStatusFinished({
   deploymentTableName,
   deploymentId,
   deploymentAlias,
+  prerenders,
+  routes,
+  lambdaRoutes,
 }: UpdateDeploymentStatusFinishedOptions) {
   return updateDeployment({
     dynamoDBClient,
@@ -40,6 +60,9 @@ function updateDeploymentStatusFinished({
     updateAttributes: {
       DeploymentAlias: deploymentAlias,
       Status: 'FINISHED',
+      LambdaRoutes: lambdaRoutes,
+      Prerenders: prerenders,
+      Routes: routes,
     },
   });
 }

--- a/packages/proxy-config/src/actions/deployment-file-exists.ts
+++ b/packages/proxy-config/src/actions/deployment-file-exists.ts
@@ -31,12 +31,13 @@ async function deploymentFileExists({
   }
 
   const decodedKey = decodeURIComponent(key);
+  const absoluteKey = deploymentId + '/static/' + decodedKey;
 
   try {
     const result = await s3Client
       .headObject({
         Bucket: s3BucketId,
-        Key: deploymentId + '/static/' + decodedKey,
+        Key: absoluteKey,
       })
       .promise();
 
@@ -44,7 +45,7 @@ async function deploymentFileExists({
       status: '200',
       body: JSON.stringify({
         status: 200,
-        key: decodedKey,
+        key: absoluteKey,
         cacheControl: result.CacheControl,
         contentType: result.ContentType,
       }),

--- a/packages/proxy/src/actions/fetch-file-system.ts
+++ b/packages/proxy/src/actions/fetch-file-system.ts
@@ -21,9 +21,7 @@ function fetchFileSystem(
   deploymentId: string,
   filePath: string
 ): Promise<FileSystemEntry | null> {
-  const url = `${endpointUrl}/filesystem/${deploymentId}/${encodeURIComponent(
-    filePath
-  )}`;
+  const url = `${endpointUrl}/filesystem/${deploymentId}/${filePath}`;
   const cacheKey = deploymentId + filePath;
   return fetchCached(fetch, cache, url, cacheKey);
 }

--- a/packages/proxy/src/handler.ts
+++ b/packages/proxy/src/handler.ts
@@ -201,7 +201,7 @@ async function handler(
     const notFound =
       proxyResult.phase === 'error' && proxyResult.status === 404;
     const uri = !notFound && proxyResult.found ? proxyResult.dest : undefined;
-    return serveRequestFromS3Origin(request, proxyConfig.deploymentId, uri);
+    return serveRequestFromS3Origin(request, uri);
   } catch (error: any) {
     if (!error.isHandled) {
       // Log full error message to CloudWatch Logs

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -106,7 +106,7 @@ export class Proxy {
       );
 
       if (file) {
-        return requestedFilePathWithoutTrailingSlash;
+        return '/' + file.key;
       }
     } catch (error) {
       console.error(

--- a/packages/proxy/src/types.ts
+++ b/packages/proxy/src/types.ts
@@ -41,4 +41,5 @@ export interface RouteResult {
 
 export type FileSystemEntry = {
   etag: string;
+  key: string;
 };

--- a/packages/proxy/src/util/custom-origin.ts
+++ b/packages/proxy/src/util/custom-origin.ts
@@ -120,12 +120,10 @@ function serveRequestFromCustomOrigin(
  *
  * @param request Incoming request from the handler. Gets modified by the
  *                function.
- * @param deploymentId DeploymentId that should be used to serve the content.
  * @returns Modified request that is served from S3.
  */
 function serveRequestFromS3Origin(
   request: CloudFrontRequest,
-  deploymentId: string,
   uri?: string
 ): CloudFrontRequest {
   // Modify `Host` header to match the S3 host. If the `Host` header is
@@ -141,7 +139,7 @@ function serveRequestFromS3Origin(
   });
 
   if (typeof uri === 'string') {
-    request.uri = `/${deploymentId}/static${uri}`;
+    request.uri = uri;
   }
 
   // Querystring is not supported by S3 origin

--- a/packages/proxy/test/handler.test.ts
+++ b/packages/proxy/test/handler.test.ts
@@ -20,9 +20,7 @@ class ConfigServer {
     this.server = createServer((req, res) => {
       if (req.url && req.url.startsWith('/filesystem')) {
         const splittedUrl = req.url.split('/');
-        const filePath = decodeURIComponent(
-          splittedUrl[splittedUrl.length - 1]
-        );
+        const filePath = splittedUrl.slice(3).join('/');
 
         if (this.proxyConfig && this.staticFiles.includes(filePath)) {
           res.statusCode = 200;

--- a/packages/proxy/test/handler.test.ts
+++ b/packages/proxy/test/handler.test.ts
@@ -24,12 +24,17 @@ class ConfigServer {
           splittedUrl[splittedUrl.length - 1]
         );
 
-        if (this.staticFiles.includes(filePath)) {
+        if (this.proxyConfig && this.staticFiles.includes(filePath)) {
           res.statusCode = 200;
+          return res.end(
+            JSON.stringify({
+              key: this.proxyConfig.deploymentId + '/static/' + filePath,
+            })
+          );
         } else {
           res.statusCode = 404;
+          return res.end(JSON.stringify({}));
         }
-        return res.end(JSON.stringify({}));
       }
 
       // Respond with config
@@ -283,12 +288,16 @@ describe('[proxy] Handler', () => {
           dest: '/en',
           continue: true,
         },
+        {
+          handle: 'filesystem',
+        },
       ],
     };
     const requestPath = '/';
 
     // Prepare configServer
     configServer.proxyConfig = proxyConfig;
+    configServer.staticFiles = ['en'];
     const cloudFrontEvent = generateCloudFrontRequestEvent({
       configEndpoint,
       uri: requestPath,

--- a/packages/proxy/test/proxy.test.ts
+++ b/packages/proxy/test/proxy.test.ts
@@ -17,7 +17,13 @@ describe('Proxy', () => {
             url ===
             `http://localhost/filesystem/123/${encodeURIComponent(staticRoute)}`
           ) {
-            return generateMockedFetchResponse(200, {}, { etag: '"found"' });
+            return generateMockedFetchResponse(
+              200,
+              {
+                key: staticRoute,
+              },
+              { etag: '"found"' }
+            );
           }
         }
 

--- a/packages/proxy/test/proxy.unit.test.ts
+++ b/packages/proxy/test/proxy.unit.test.ts
@@ -373,13 +373,18 @@ describe('Proxy unit', () => {
   test('With trailing slash', async () => {
     const mockedFetch = jest.fn().mockImplementation((url: string) => {
       if (
-        url ===
-          `http://localhost/filesystem/123/${encodeURIComponent(
-            'test/index'
-          )}` ||
-        url === `http://localhost/filesystem/123/${encodeURIComponent('index')}`
+        url === 'http://localhost/filesystem/123/test/index' ||
+        url === 'http://localhost/filesystem/123/index'
       ) {
-        return generateMockedFetchResponse(200, {}, { etag: '"found"' });
+        return generateMockedFetchResponse(
+          200,
+          {
+            key:
+              '123/static/' +
+              url.substring('http://localhost/filesystem/123/'.length),
+          },
+          { etag: '"found"' }
+        );
       }
 
       return generateMockedFetchResponse(404, {}, { etag: '"notfound"' });
@@ -400,7 +405,7 @@ describe('Proxy unit', () => {
     );
     expect(result1).toEqual({
       found: true,
-      dest: '/test/index',
+      dest: '/123/static/test/index',
       continue: false,
       status: undefined,
       headers: {},
@@ -418,7 +423,7 @@ describe('Proxy unit', () => {
     );
     expect(result2).toEqual({
       found: true,
-      dest: '/index',
+      dest: '/123/static/index',
       continue: false,
       status: undefined,
       headers: {},
@@ -648,10 +653,14 @@ describe('Proxy unit', () => {
 
   test('Static index route', async () => {
     const mockedFetch = jest.fn().mockImplementation((url: string) => {
-      if (
-        url === `http://localhost/filesystem/123/${encodeURIComponent('index')}`
-      ) {
-        return generateMockedFetchResponse(200, {}, { etag: '"found"' });
+      if (url === 'http://localhost/filesystem/123/index') {
+        return generateMockedFetchResponse(
+          200,
+          {
+            key: '123/static/index',
+          },
+          { etag: '"found"' }
+        );
       }
 
       return generateMockedFetchResponse(404, {}, { etag: '"notfound"' });
@@ -671,7 +680,7 @@ describe('Proxy unit', () => {
 
     expect(result).toEqual({
       found: true,
-      dest: '/index',
+      dest: '/123/static/index',
       target: 'filesystem',
       continue: false,
       status: undefined,
@@ -683,13 +692,14 @@ describe('Proxy unit', () => {
 
   test('Multiple dynamic parts', async () => {
     const mockedFetch = jest.fn().mockImplementation((url: string) => {
-      if (
-        url ===
-        `http://localhost/filesystem/123/${encodeURIComponent(
-          '[teamSlug]/[project]/[id]'
-        )}`
-      ) {
-        return generateMockedFetchResponse(200, {}, { etag: '"found"' });
+      if (url === 'http://localhost/filesystem/123/[teamSlug]/[project]/[id]') {
+        return generateMockedFetchResponse(
+          200,
+          {
+            key: '123/static/[teamSlug]/[project]/[id]',
+          },
+          { etag: '"found"' }
+        );
       }
 
       return generateMockedFetchResponse(404, {}, { etag: '"notfound"' });
@@ -721,7 +731,7 @@ describe('Proxy unit', () => {
 
     expect(result).toEqual({
       found: true,
-      dest: '/[teamSlug]/[project]/[id]',
+      dest: '/123/static/[teamSlug]/[project]/[id]',
       target: 'filesystem',
       continue: false,
       status: undefined,
@@ -733,13 +743,14 @@ describe('Proxy unit', () => {
 
   test('Dynamic static route', async () => {
     const mockedFetch = jest.fn().mockImplementation((url: string) => {
-      if (
-        url ===
-        `http://localhost/filesystem/123/${encodeURIComponent(
-          'users/[user_id]'
-        )}`
-      ) {
-        return generateMockedFetchResponse(200, {}, { etag: '"found"' });
+      if (url === 'http://localhost/filesystem/123/users/[user_id]') {
+        return generateMockedFetchResponse(
+          200,
+          {
+            key: '123/static/users/[user_id]',
+          },
+          { etag: '"found"' }
+        );
       }
 
       return generateMockedFetchResponse(404, {}, { etag: '"notfound"' });
@@ -767,7 +778,7 @@ describe('Proxy unit', () => {
 
     expect(result).toEqual({
       found: true,
-      dest: '/users/[user_id]',
+      dest: '/123/static/users/[user_id]',
       target: 'filesystem',
       continue: false,
       status: undefined,


### PR DESCRIPTION
Static deployments without Lambdas failed previously, since they would create an empty CloudFormation template.
This PR fixes this by only creating a CloudFormation template when Lambdas are in the deployment.