### PR TITLE
Bring back lambda_attach_to_vpc variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -210,6 +210,10 @@ module "deploy_controller" {
 
   debug_use_local_packages = var.debug_use_local_packages
   tf_next_module_root      = path.module
+
+  lambda_attach_to_vpc   = var.lambda_attach_to_vpc
+  vpc_subnet_ids         = var.vpc_subnet_ids
+  vpc_security_group_ids = var.vpc_security_group_ids
 }
 
 ###################
@@ -266,6 +270,10 @@ module "api" {
 
   debug_use_local_packages = var.debug_use_local_packages
   tf_next_module_root      = path.module
+
+  lambda_attach_to_vpc   = var.lambda_attach_to_vpc
+  vpc_subnet_ids         = var.vpc_subnet_ids
+  vpc_security_group_ids = var.vpc_security_group_ids
 }
 
 ############

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -88,6 +88,10 @@ module "lambda" {
   tags = var.tags
 
   debug_use_local_packages = var.debug_use_local_packages
+
+  lambda_attach_to_vpc   = var.lambda_attach_to_vpc
+  vpc_subnet_ids         = var.vpc_subnet_ids
+  vpc_security_group_ids = var.vpc_security_group_ids
 }
 
 #############

--- a/modules/api/variables.tf
+++ b/modules/api/variables.tf
@@ -47,6 +47,24 @@ variable "upload_bucket_arn" {
   type = string
 }
 
+variable "lambda_attach_to_vpc" {
+  type        = bool
+  description = "Set to true if the Lambda functions should be attached to a VPC. Use this setting if VPC resources should be accessed by the Lambda functions. When setting this to true, use vpc_security_group_ids and vpc_subnet_ids to specify the VPC networking. Note that attaching to a VPC would introduce a delay on to cold starts"
+  default     = false
+}
+
+variable "vpc_subnet_ids" {
+  type        = list(string)
+  description = "The list of VPC subnet IDs to attach the Lambda functions. lambda_attach_to_vpc should be set to true for these to be applied."
+  default     = []
+}
+
+variable "vpc_security_group_ids" {
+  type        = list(string)
+  description = "The list of Security Group IDs to be used by the Lambda functions. lambda_attach_to_vpc should be set to true for these to be applied."
+  default     = []
+}
+
 ##########
 # Labeling
 ##########

--- a/modules/deploy-controller/main.tf
+++ b/modules/deploy-controller/main.tf
@@ -99,6 +99,10 @@ module "worker" {
     }
   }
 
+  lambda_attach_to_vpc   = var.lambda_attach_to_vpc
+  vpc_subnet_ids         = var.vpc_subnet_ids
+  vpc_security_group_ids = var.vpc_security_group_ids
+
   tags = var.tags
 
   debug_use_local_packages = var.debug_use_local_packages

--- a/modules/deploy-controller/variables.tf
+++ b/modules/deploy-controller/variables.tf
@@ -31,6 +31,25 @@ variable "dynamodb_table_deployments_name" {
   type = string
 }
 
+variable "lambda_attach_to_vpc" {
+  type        = bool
+  description = "Set to true if the Lambda functions should be attached to a VPC. Use this setting if VPC resources should be accessed by the Lambda functions. When setting this to true, use vpc_security_group_ids and vpc_subnet_ids to specify the VPC networking. Note that attaching to a VPC would introduce a delay on to cold starts"
+  default     = false
+}
+
+variable "vpc_subnet_ids" {
+  type        = list(string)
+  description = "The list of VPC subnet IDs to attach the Lambda functions. lambda_attach_to_vpc should be set to true for these to be applied."
+  default     = []
+}
+
+variable "vpc_security_group_ids" {
+  type        = list(string)
+  description = "The list of Security Group IDs to be used by the Lambda functions. lambda_attach_to_vpc should be set to true for these to be applied."
+  default     = []
+}
+
+
 ######################
 # Multiple deployments
 ######################

--- a/modules/lambda-worker/iam.tf
+++ b/modules/lambda-worker/iam.tf
@@ -30,7 +30,7 @@ resource "aws_iam_role" "lambda" {
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_vpc" {
-  role       = aws_iam_role.lambda
+  role       = aws_iam_role.lambda.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 

--- a/modules/lambda-worker/iam.tf
+++ b/modules/lambda-worker/iam.tf
@@ -29,6 +29,11 @@ resource "aws_iam_role" "lambda" {
   tags = var.tags
 }
 
+resource "aws_iam_role_policy_attachment" "lambda_vpc" {
+  role       = aws_iam_role.lambda
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
 #################
 # Cloudwatch Logs
 #################

--- a/modules/lambda-worker/main.tf
+++ b/modules/lambda-worker/main.tf
@@ -59,6 +59,14 @@ resource "aws_lambda_function" "this" {
     }
   }
 
+  dynamic "vpc_config" {
+    for_each = var.lambda_attach_to_vpc ? [true] : []
+    content {
+      security_group_ids = var.vpc_security_group_ids
+      subnet_ids         = var.vpc_subnet_ids
+    }
+  }
+
   tags = var.tags
 
   # Wait until the creation of the log group is finished before the lambda is

--- a/modules/lambda-worker/variables.tf
+++ b/modules/lambda-worker/variables.tf
@@ -111,6 +111,25 @@ variable "policy_jsons" {
   default     = []
 }
 
+variable "lambda_attach_to_vpc" {
+  type        = bool
+  description = "Set to true if the Lambda functions should be attached to a VPC. Use this setting if VPC resources should be accessed by the Lambda functions. When setting this to true, use vpc_security_group_ids and vpc_subnet_ids to specify the VPC networking. Note that attaching to a VPC would introduce a delay on to cold starts"
+  default     = false
+}
+
+variable "vpc_subnet_ids" {
+  type        = list(string)
+  description = "The list of VPC subnet IDs to attach the Lambda functions. lambda_attach_to_vpc should be set to true for these to be applied."
+  default     = []
+}
+
+variable "vpc_security_group_ids" {
+  type        = list(string)
+  description = "The list of Security Group IDs to be used by the Lambda functions. lambda_attach_to_vpc should be set to true for these to be applied."
+  default     = []
+}
+
+
 ##########
 # Labeling
 ##########


### PR DESCRIPTION
The variable still exists in `variable.tf` but can't find a single use of it on `main.tf`. Did we deprecate this option?

Tried to add it in an appropriate place, but after applied with terraform , every deployment with `tf-next deploy` get failed.

Any help/guidance would be appreciated